### PR TITLE
ENH: Log messages are *much* more useful when they appear in reverse chro

### DIFF
--- a/apptools/logger/plugin/view/logger_view.py
+++ b/apptools/logger/plugin/view/logger_view.py
@@ -124,8 +124,10 @@ class LoggerView(TraitsUIView):
         """
         service = self.service
         if service.handler.has_new_records() or force:
-            self.log_records = [ rec for rec in service.handler.get()
-                                 if rec.levelno >= service.preferences.level_ ]
+            log_records = [ rec for rec in service.handler.get()
+                            if rec.levelno >= service.preferences.level_ ]
+            log_records.reverse()
+            self.log_records = log_records
 
     ###########################################################################
     # Private interface


### PR DESCRIPTION
ENH: Log messages are _much_ more useful when they appear in reverse chronological order.  This prevents us from having to constantly keep scrolling down to the bottom of the logging window.
