### PR TITLE
Configobj is now a mandatory dependency of apptools.

### DIFF
--- a/apptools/__init__.py
+++ b/apptools/__init__.py
@@ -5,4 +5,5 @@ __version__ = '4.0.2'
 
 __requires__ = [
     'traitsui',
+    'configobj',
 ]


### PR DESCRIPTION
Configobj is now a mandatory dependency, therefore has been added to the requires and it will be downloaded automatically when a user install Mayavi from pipy.
