### PR TITLE
BUG: url should have three slashes after the 'file' scheme

### DIFF
--- a/apptools/io/file.py
+++ b/apptools/io/file.py
@@ -201,7 +201,8 @@ class File(HasPrivateTraits):
     def _get_url(self):
         """ Returns the path as a URL. """
 
-        return 'file://%s' % self.absolute_path
+        # Strip out the leading slash on POSIX systems.
+        return 'file:///%s' % self.absolute_path.lstrip('/')
 
     #### Methods ##############################################################
 


### PR DESCRIPTION
On windows, the url attribute of a File object had only 'file://'
instead of 'file:///'.  This commit fixes it.
