### PR TITLE
Ignore path if we're not allowed to access it.

### DIFF
--- a/apptools/io/file.py
+++ b/apptools/io/file.py
@@ -15,11 +15,22 @@
 
 
 # Standard/built-in imports.
-import mimetypes, os, shutil, stat
+import os
+import sys
+import stat
+import shutil
+import mimetypes
 
 # Enthought library imports.
 from traits.api import Bool, HasPrivateTraits, Instance, List, Property
 from traits.api import Str
+
+
+# Permissions errors are different on Windows than other systems.
+if sys.platform == 'win32':
+    AccessError = WindowsError
+else:
+    AccessError = OSError
 
 
 class File(HasPrivateTraits):
@@ -113,8 +124,13 @@ class File(HasPrivateTraits):
         """
 
         if self.is_folder:
+            try:
+                contents = os.listdir(self.path)
+            except AccessError:
+                return None
+
             children = []
-            for name in os.listdir(self.path):
+            for name in contents:
                 children.append(File(os.path.join(self.path, name)))
 
         else:


### PR DESCRIPTION
Don't try to list the contents of a path if we don't have access to it.

This issue is particularly common on Windows where user directories are more likely to contain protected paths. Running the [tree editor traitsui demo](https://github.com/enthought/traitsui/blob/master/examples/demo/Advanced/Adapted_tree_editor_demo.py) from the user's root directory in Windows will reproduce this error (at least on my system, the `Application Data` directory gives errors). Alternatively, you can run the example with a dummy directory:

```
mkdir nonreadable
chmod a-r nonreadable
python Adapted_tree_editor_demo.py
```
