### PR TITLE
Remove the 'enth_type' attribute used by H5DictNode and H5TableNode

### DIFF
--- a/apptools/io/h5/dict_node.py
+++ b/apptools/io/h5/dict_node.py
@@ -31,9 +31,6 @@ class H5DictNode(object):
         Otherwise, call `flush()` explicitly to write data to disk.
     """
 
-    #: Label added to H5 group's 'enth_type' attribute to identify node type.
-    _enth_type = 'h5_dict_node'
-
     #: Name of filenode where dict data is stored.
     _pyobject_data_node = '_pyobject_data'
 
@@ -106,7 +103,6 @@ class H5DictNode(object):
         """
         h5.create_group(node_path)
         group = h5[node_path]
-        group.attrs['enth_type'] = cls._enth_type
 
         cls._create_pyobject_node(h5._h5, node_path, data=data)
         return cls(group, **kwargs)
@@ -126,8 +122,8 @@ class H5DictNode(object):
 
         if not isinstance(pytables_node, PyTablesGroup):
             return False
-        attrs = pytables_node._v_attrs
-        return 'enth_type' in attrs and attrs['enth_type'] == cls._enth_type
+
+        return cls._pyobject_data_node in pytables_node._v_children
 
     #--------------------------------------------------------------------------
     #  Private interface

--- a/apptools/io/h5/table_node.py
+++ b/apptools/io/h5/table_node.py
@@ -22,9 +22,6 @@ class H5TableNode(object):
         An H5 node which is a pytables.Table or H5TableNode instance
     """
 
-    #: Label added to H5 group's 'enth_type' attribute to identify node type.
-    _enth_type = 'h5_table_node'
-
     def __init__(self, node):
         # Avoid a circular import
         from .file import H5Attrs
@@ -60,7 +57,6 @@ class H5TableNode(object):
 
         cls._create_pytables_node(h5, node_path, description, **kwargs)
         node = h5[node_path]
-        node.attrs['enth_type'] = cls._enth_type
 
         return cls(node)
 


### PR DESCRIPTION
It's a bit too magic, and it creates backwards compatibility problems.

This was causing trouble in some product code which used an earlier version of this code. The attribute name `enth_type` was changed from a product-specific name. That causes problems when reading old data with this code. It turns out that checking for a child node named `_pyobject_data` in the group created by `H5DictNode` is a sufficient test.
