### PR TITLE
Add error message when calling `remove_node` on a group

### DIFF
--- a/apptools/io/h5/file.py
+++ b/apptools/io/h5/file.py
@@ -273,6 +273,9 @@ class H5File(Mapping):
             PyTable node path; e.g. '/path/to/node'.
         """
         node = self[node_path]
+        if isinstance(node, H5Group):
+            msg = "{!r} is a group. Use `remove_group` to remove group nodes."
+            raise ValueError(msg.format(node.pathname))
         node._f_remove()
 
     def remove_group(self, group_path, **kwargs):

--- a/apptools/io/h5/tests/test_dict_node.py
+++ b/apptools/io/h5/tests/test_dict_node.py
@@ -18,6 +18,19 @@ def test_create():
         assert h5dict['b'] == 2
 
 
+def test_is_dict_node():
+    with temp_h5_file() as h5:
+        node = h5.create_dict(NODE, {})
+        assert H5DictNode.is_dict_node(node._h5_group)
+
+
+def test_is_not_dict_node():
+    with temp_h5_file() as h5:
+        node = h5.create_group(NODE)
+        assert not H5DictNode.is_dict_node(node)
+        assert not H5DictNode.is_dict_node(node._h5_group)
+
+
 def test_create_with_data():
     with temp_h5_file() as h5:
         data = {'a': 10}

--- a/apptools/io/h5/tests/test_file.py
+++ b/apptools/io/h5/tests/test_file.py
@@ -282,6 +282,14 @@ def test_remove_group_with_H5Group():
         assert node_path not in h5
 
 
+@testing.raises(ValueError)
+def test_remove_group_with_remove_node():
+    node_path = '/group'
+    with open_h5file(H5_TEST_FILE, mode='w') as h5:
+        h5.create_group(node_path)
+        h5.remove_node(node_path)  # Groups should be removed w/ `remove_group`
+
+
 def test_remove_node_with_H5File():
     with open_h5file(H5_TEST_FILE, mode='w', delete_existing=True) as h5:
         h5.create_array('/array', np.arange(3))


### PR DESCRIPTION
The current error message returned when calling `remove_node` on a group is not really helpful.

This also add some unrelated testing for `is_dict_node`. (It came up while debugging.)
