### PR TITLE
Backport and traitsify python 3.x's functools.lru_cache

### DIFF
--- a/apptools/lru_cache/__init__.py
+++ b/apptools/lru_cache/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from lru_cache import LRUCache

--- a/apptools/lru_cache/__init__.py
+++ b/apptools/lru_cache/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from lru_cache import LRUCache

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from threading import RLock
+import logging
+
+from traits.api import Callable, Dict, Event, HasStrictTraits, Instance, Int, \
+    List, Str
+
+logger = logging.getLogger(__name__)
+
+
+class LRUCache(HasStrictTraits):
+    """ A least-recently used cache.
+
+    Items older than `size()` accesses are dropped from the cache.
+
+    This is ported from python 3's functools.lru_cache.
+
+    """
+
+    size = Int
+
+    # Called with the key and value that was dropped from the cache
+    cache_drop_callback = Callable
+
+    # This event contains the set of cached cell keys whenever it changes
+    updated = Event()
+
+    _lock = Instance(RLock, args=())
+
+    _cache = Dict
+    _root = List
+
+    _tag = Str("LRUCache")
+
+    def __init__(self, size, **traits):
+        self.size = size
+        self._cache = {}
+        self._root = []  # root of the circular doubly linked list
+        # initialize by pointing to self
+        self._root[:] = [self._root, self._root, None, None]
+        super(LRUCache, self).__init__(**traits)
+
+    # -------------------------------------------------------------------------
+    # Traits defaults
+    # -------------------------------------------------------------------------
+
+    def _cache_drop_callback_default(self):
+        def callback(key, value):
+            msg = "Tag: {!r} cache drop {{{}: {}}}"
+            logger.debug(msg.format(self._tag, key, value))
+        return callback
+
+    # -------------------------------------------------------------------------
+    # Traits change properties
+    # -------------------------------------------------------------------------
+
+    # -------------------------------------------------------------------------
+    # Traits change handlers
+    # -------------------------------------------------------------------------
+
+    def _cache_drop_callback_changed(self, callback):
+        self._cache.callback = callback
+
+    # -------------------------------------------------------------------------
+    # LRUCache interface
+    # -------------------------------------------------------------------------
+
+    def __contains__(self, key):
+        with self._lock:
+            return key in self._cache
+
+    def __len__(self):
+        with self._lock:
+            return len(self._cache)
+
+    def __getitem__(self, key):
+        PREV, NEXT = 0, 1   # names for the link fields
+        # Size limited caching that tracks accesses by recency
+        try:
+            with self._lock:
+                link = self._cache[key]
+                if link is not None:
+                    # Move the link to the front of the circular queue
+                    link_prev, link_next, _key, result = link
+                    link_prev[NEXT] = link_next
+                    link_next[PREV] = link_prev
+                    last = self._root[PREV]
+                    last[NEXT] = self._root[PREV] = link
+                    link[PREV] = last
+                    link[NEXT] = self._root
+                    return result
+        finally:
+            self.updated = self.keys()
+
+    def __setitem__(self, key, result):
+        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3   # names for the link fields
+        try:
+            with self._lock:
+                if len(self) == self.size:
+                    # Use the old root to store the new key and result.
+                    oldroot = self._root
+                    oldroot[KEY] = key
+                    oldroot[RESULT] = result
+                    # Empty the oldest link and make it the new root.
+                    # Keep a reference to the old key and old result to
+                    # prevent their ref counts from going to zero during the
+                    # update. That will prevent potentially arbitrary object
+                    # clean-up code (i.e. __del__) from running while we're
+                    # still adjusting the links.
+                    self._root = oldroot[NEXT]
+                    oldkey = self._root[KEY]
+                    oldresult = self._root[RESULT]
+                    self._root[KEY] = self._root[RESULT] = None
+                    # Now update the cache dictionary.
+                    del self._cache[oldkey]
+                    if oldkey != key:
+                        self.cache_drop_callback(oldkey, oldresult)
+                    # Save the potentially reentrant cache[key] assignment
+                    # for last, after the root and links have been put in
+                    # a consistent state.
+                    self._cache[key] = oldroot
+                else:
+                    # Put result in a new link at the front of the queue.
+                    last = self._root[PREV]
+                    link = [last, self._root, key, result]
+                    last[NEXT] = self._root[PREV] = self._cache[key] = link
+            return None
+        finally:
+            self.updated = self.keys()
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def items(self):
+        with self._lock:
+            return [(key, link[3]) for key, link in self._cache.items()]
+
+    def keys(self):
+        items = self.items()
+        return zip(*items)[0] if items else []
+
+    def values(self):
+        items = self.items()
+        return zip(*items)[1] if items else []
+
+    def clear(self):
+        with self._lock:
+            self._cache = {}
+            self._root = []  # root of the circular doubly linked list
+            # initialize by pointing to self
+            self._root[:] = [self._root, self._root, None, None]
+        self.updated = []
+        return

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -65,13 +65,6 @@ class LRUCache(HasStrictTraits):
             self._root[:] = [self._root, self._root, None, None]
 
     # -------------------------------------------------------------------------
-    # Traits change handlers
-    # -------------------------------------------------------------------------
-
-    def _cache_drop_callback_changed(self, callback):
-        self._cache.callback = callback
-
-    # -------------------------------------------------------------------------
     # LRUCache interface
     # -------------------------------------------------------------------------
 

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -12,7 +12,7 @@
 #
 # The circular buffer implementation was backported from Python 3.4 and is
 # provided under the PSF License available at
-# https://docs.python.org/3.4/license.html.
+# https://docs.python.org/3.4/license.html
 #
 # Author: Enthought, Inc.
 #------------------------------------------------------------------------------

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -1,5 +1,22 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+#------------------------------------------------------------------------------
+# Copyright (c) 2015, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+#
+# The circular buffer implementation was backported from Python 3.4 and is
+# provided under the PSF License available at
+# https://docs.python.org/3.4/license.html.
+#
+# Author: Enthought, Inc.
+#------------------------------------------------------------------------------
+
 
 from threading import RLock
 import logging

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -78,21 +78,18 @@ class LRUCache(HasStrictTraits):
     def __getitem__(self, key):
         PREV, NEXT = 0, 1   # names for the link fields
         # Size limited caching that tracks accesses by recency
-        try:
-            with self._lock:
-                link = self._cache[key]
-                if link is not None:
-                    # Move the link to the front of the circular queue
-                    link_prev, link_next, _key, result = link
-                    link_prev[NEXT] = link_next
-                    link_next[PREV] = link_prev
-                    last = self._root[PREV]
-                    last[NEXT] = self._root[PREV] = link
-                    link[PREV] = last
-                    link[NEXT] = self._root
-                    return result
-        finally:
-            self.updated = self.keys()
+        with self._lock:
+            link = self._cache[key]
+            if link is not None:
+                # Move the link to the front of the circular queue
+                link_prev, link_next, _key, result = link
+                link_prev[NEXT] = link_next
+                link_next[PREV] = link_prev
+                last = self._root[PREV]
+                last[NEXT] = self._root[PREV] = link
+                link[PREV] = last
+                link[NEXT] = self._root
+                return result
 
     def __setitem__(self, key, result):
         PREV, NEXT, KEY, RESULT = 0, 1, 2, 3   # names for the link fields
@@ -142,11 +139,11 @@ class LRUCache(HasStrictTraits):
 
     def keys(self):
         items = self.items()
-        return zip(*items)[0] if items else []
+        return [k for k, v in items]
 
     def values(self):
         items = self.items()
-        return zip(*items)[1] if items else []
+        return [v for k, v in items]
 
     def clear(self):
         with self._lock:

--- a/apptools/lru_cache/tests/test_lru_cache.py
+++ b/apptools/lru_cache/tests/test_lru_cache.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, print_function
 
-from numpy.testing import assert_equal
+from nose.tools import assert_equal
 
 from ..lru_cache import LRUCache
 
@@ -111,3 +111,28 @@ def test_cache_get():
         c[i] = i
     assert_equal(0, c.get(0))
     assert_equal(None, c.get(c.size))
+
+
+def test_updated_event():
+    c = LRUCache(2)
+    events = []
+
+    # Traits can't handle builtins as handlers
+    c.on_trait_change(lambda x: events.append(x), 'updated')
+
+    c[0] = 0
+    print(c.keys())
+    assert_equal(sorted(events), [[0]])
+
+    c[1] = 1
+    assert_equal(sorted(events), [[0], [0, 1]])
+
+    c[2] = 2
+    assert_equal(sorted(events), [[0], [0, 1], [1, 2]])
+
+    # Getting items doesn't fire anything
+    c[1]
+    assert_equal(sorted(events), [[0], [0, 1], [1, 2]])
+
+    c.get(3)
+    assert_equal(sorted(events), [[0], [0, 1], [1, 2]])

--- a/apptools/lru_cache/tests/test_lru_cache.py
+++ b/apptools/lru_cache/tests/test_lru_cache.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+from numpy.testing import assert_equal
+
+from ..lru_cache import LRUCache
+
+
+def test_cache_callback():
+    dropped = []
+    callback = lambda *args: dropped.append(args)
+    c = LRUCache(2, cache_drop_callback=callback)
+    for i in range(5):
+        c[i] = str(i)
+
+    expected = [(0, '0'), (1, '1'), (2, '2')]
+    assert_equal(expected, dropped)
+
+
+def test_cache_len():
+    c = LRUCache(2)
+    assert_equal(0, len(c))
+    assert_equal(2, c.size)
+    c[0] = None
+    assert_equal(1, len(c))
+    assert_equal(2, c.size)
+    c[1] = None
+    assert_equal(2, len(c))
+    assert_equal(2, c.size)
+    c[2] = None
+    assert_equal(2, len(c))
+    assert_equal(2, c.size)
+
+
+def test_cache_resize():
+    c = LRUCache(1)
+    c[0] = 0
+    c[1] = 1
+
+    assert_equal(1, len(c))
+    assert_equal(1, c.size)
+    assert 0 not in c
+    assert 1 in c
+
+    c.size = 3
+    assert_equal(1, len(c))
+    assert_equal(3, c.size)
+    assert 1 in c
+
+    c[2] = 2
+    assert_equal(2, len(c))
+    assert_equal(3, c.size)
+    assert 1 in c
+    assert 2 in c
+
+    c[3] = 3
+    assert_equal(3, len(c))
+    assert_equal(3, c.size)
+    assert 1 in c
+    assert 2 in c
+    assert 3 in c
+
+    c[4] = 4
+    assert_equal(3, len(c))
+    assert_equal(3, c.size)
+    assert 1 not in c
+    assert 2 in c
+    assert 3 in c
+    assert 4 in c
+
+
+def test_cache_items():
+    c = LRUCache(2)
+    assert_equal([], c.items())
+
+    c[0] = str(0)
+    c[1] = str(1)
+    c[2] = str(2)
+
+    expected = [(1, '1'), (2, '2')]
+    assert_equal(expected, sorted(c.items()))
+
+
+def test_cache_keys_values():
+    c = LRUCache(2)
+    assert_equal([], c.items())
+
+    c[0] = str(0)
+    c[1] = str(1)
+    c[2] = str(2)
+
+    expected = [1, 2]
+    assert_equal(expected, sorted(c.keys()))
+    assert_equal(map(str, expected), sorted(c.values()))
+
+
+def test_cache_clear():
+    c = LRUCache(2)
+    for i in range(c.size):
+        c[i] = i
+    assert_equal(c.size, len(c))
+    c.clear()
+    assert_equal(0, len(c))
+
+
+def test_cache_get():
+    c = LRUCache(2)
+    for i in range(c.size):
+        c[i] = i
+    assert_equal(0, c.get(0))
+    assert_equal(None, c.get(c.size))


### PR DESCRIPTION
This brings a `trait`'d `LRUCache` to python 2.x by adapting the decorator found in `functools.lru_cache` at https://hg.python.org/cpython/file/4d4a9094bdb0/Lib/functools.py