### PR TITLE
Reimplement LRUCache on top of OrderedDict.

### DIFF
--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -10,10 +10,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 #
-# The circular buffer implementation was backported from Python 3.4 and is
-# provided under the PSF License available at
-# https://docs.python.org/3.4/license.html
-#
 # Author: Enthought, Inc.
 #------------------------------------------------------------------------------
 

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -16,11 +16,8 @@
 
 from threading import RLock
 from collections import OrderedDict
-import logging
 
 from traits.api import Callable, Event, HasStrictTraits, Instance, Int
-
-logger = logging.getLogger(__name__)
 
 
 class LRUCache(HasStrictTraits):

--- a/apptools/lru_cache/lru_cache.py
+++ b/apptools/lru_cache/lru_cache.py
@@ -75,13 +75,14 @@ class LRUCache(HasStrictTraits):
 
     def __setitem__(self, key, result):
         try:
+            dropped = None
             with self._lock:
                 self._cache[key] = result
                 self._renew(key)
                 if self.size < len(self._cache):
                     dropped = self._cache.popitem(last=False)
-                    if self.cache_drop_callback is not None:
-                        self.cache_drop_callback(*dropped)
+            if dropped and self.cache_drop_callback is not None:
+                self.cache_drop_callback(*dropped)
         finally:
             self.updated = self.keys()
 
@@ -106,4 +107,4 @@ class LRUCache(HasStrictTraits):
     def clear(self):
         with self._lock:
             self._initialize_cache()
-            self.updated = []
+        self.updated = []

--- a/apptools/lru_cache/tests/test_lru_cache.py
+++ b/apptools/lru_cache/tests/test_lru_cache.py
@@ -83,6 +83,26 @@ def test_cache_items():
     assert_equal(expected, sorted(c.items()))
 
 
+def test_cache_idempotency():
+    c = LRUCache(2)
+    c[1] = 1
+    assert_equal(1, len(c))
+    c[1] = 1
+    assert_equal(1, len(c))
+
+    c[2] = 2
+    assert_equal(2, len(c))
+    c[1] = 1
+    assert_equal(2, len(c))
+    c[2] = 2
+    assert_equal(2, len(c))
+
+    c[3] = 3
+    assert_equal(2, len(c))
+    c[3] = 3
+    assert_equal(2, len(c))
+
+
 def test_cache_keys_values():
     c = LRUCache(2)
     assert_equal([], c.items())


### PR DESCRIPTION
This PR changes the newly implemented LRUCache to be based on `collections.OrderedDict` rather than the circular linked list ported from python 3. The linked list version had a bug wherein doubly-inserted values weren't properly handled and another involving recently dropped keys. It was sufficiently complicated that debugging was taking longer than reimplementing.

I'm much happier with this result anyway.