### PR TITLE
Fixing unicode support for PreferencesHelper

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,20 @@
+Apptools CHANGELOG
+==================
+
+Change summary since 4.2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enhancements
+
+ * Apptools now have a changelog!
+ * Preferences system defaults to utf-8 encoded string with ConfigObj providing
+   better support for unicode in the PreferenceHelper (#41).
+
+Changes
+
+ * 
+
+Fixes
+
+ * 
+

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -362,7 +362,7 @@ class Preferences(HasTraits):
         # use a different persistence mechanism).
         from configobj import ConfigObj
 
-        config_obj = ConfigObj(file_or_filename)
+        config_obj = ConfigObj(file_or_filename, encoding='utf-8')
 
         # 'name' is the section name, 'value' is a dictionary containing the
         # name/value pairs in the section (the actual preferences ;^).
@@ -542,8 +542,11 @@ class Preferences(HasTraits):
     def _set(self, key, value):
         """ Set the value of a preference in this node. """
 
-        # Preferences are *always* stored as strings.
-        value = str(value)
+        # Preferences are *always* stored as utf-8 strings.
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
+        else:
+            value = str(value)
 
         self._lk.acquire()
         old = self._preferences.get(key)

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -398,7 +398,7 @@ class Preferences(HasTraits):
 
             logger.debug('saving preferences to <%s>', file_or_filename)
 
-            config_obj = ConfigObj(file_or_filename)
+            config_obj = ConfigObj(file_or_filename, encoding='utf-8')
             self._add_node_to_dictionary(self, config_obj)
             config_obj.write()
 

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -542,12 +542,6 @@ class Preferences(HasTraits):
     def _set(self, key, value):
         """ Set the value of a preference in this node. """
 
-        # Preferences are *always* stored as utf-8 strings.
-        if isinstance(value, unicode):
-            value = value.encode('utf-8')
-        else:
-            value = str(value)
-
         self._lk.acquire()
         old = self._preferences.get(key)
         self._preferences[key] = value

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -132,10 +132,9 @@ class PreferencesHelper(HasTraits):
         if isinstance(handler, Str) or trait.is_str:
             pass
 
-        # If the trait type is 'Unicode' then we convert the raw value.
         elif isinstance(handler, Unicode):
             # Just in case we get back an ASCII `str` object, convert it to a
-            # `unicode` object.
+            # `unicode` object.     
             value = unicode(value) 
 
         # Otherwise, we eval it!

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -134,7 +134,8 @@ class PreferencesHelper(HasTraits):
 
         # If the trait type is 'Unicode' then we convert the raw value.
         elif isinstance(handler, Unicode):
-            # The unicode values have been serialized as utf-8 strings
+            # Just in case we get back an ASCII `str` object, convert it to a
+            # `unicode` object.
             value = unicode(value) 
 
         # Otherwise, we eval it!

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -135,7 +135,7 @@ class PreferencesHelper(HasTraits):
         # If the trait type is 'Unicode' then we convert the raw value.
         elif isinstance(handler, Unicode):
             # The unicode values have been serialized as utf-8 strings
-            value = value.decode('utf-8')
+            value = unicode(value) 
 
         # Otherwise, we eval it!
         else:

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -68,6 +68,12 @@ class PreferencesHelper(HasTraits):
         # If we were the one that set the trait (because the underlying
         # preferences node changed) then do nothing.
         if self.preferences and self._is_preference_trait(trait_name):
+            if isinstance(new, unicode):
+                # the underlying Preference class can only save strings to the
+                # file and not unicode. We make the assumpation that storing
+                # unicode objects as utf-8 string should cover us in most
+                # cases.
+                new = new.encode('utf-8')
             self.preferences.set('%s.%s' % (self._get_path(), trait_name), new)
 
         return
@@ -134,7 +140,8 @@ class PreferencesHelper(HasTraits):
 
         # If the trait type is 'Unicode' then we convert the raw value.
         elif isinstance(handler, Unicode):
-            value = unicode(value)
+            # The unicode values have been serialized as utf-8 strings
+            value = value.decode('utf-8')
 
         # Otherwise, we eval it!
         else:

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -68,12 +68,6 @@ class PreferencesHelper(HasTraits):
         # If we were the one that set the trait (because the underlying
         # preferences node changed) then do nothing.
         if self.preferences and self._is_preference_trait(trait_name):
-            if isinstance(new, unicode):
-                # the underlying Preference class can only save strings to the
-                # file and not unicode. We make the assumpation that storing
-                # unicode objects as utf-8 string should cover us in most
-                # cases.
-                new = new.encode('utf-8')
             self.preferences.set('%s.%s' % (self._get_path(), trait_name), new)
 
         return

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -220,7 +220,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         helper.description = u'caf\xe9'
         self.assertEqual(u'caf\xe9', helper.description)
-        self.assertEqual('caf\xc3\xa9', p.get('acme.ui.description'))
+        self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
 
     def test_no_preferences_path(self):
         """ no preferences path """
@@ -475,11 +475,11 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # ratio to get set via the static trait change handler on the helper.
         p.set('acme.ui.width', 42)
         self.assertEqual(42, helper.width)
-        self.assertEqual('42', p.get('acme.ui.width'))
+        self.assertEqual(42, p.get('acme.ui.width'))
 
         # Did the ratio get changed?
         self.assertEqual(3.0, helper.ratio)
-        self.assertEqual('3.0', p.get('acme.ui.ratio'))
+        self.assertEqual(3.0, p.get('acme.ui.ratio'))
 
         return
 

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -212,7 +212,13 @@ class PreferencesHelperTestCase(unittest.TestCase):
             preferences_path = 'acme.ui'
 
             # The traits that we want to initialize from preferences.
+            bgcolor     = Str('blue')
+            width       = Int(50)
+            ratio       = Float(1.0)
+            visible     = Bool(True)
             description = Unicode(u'U\xdc\xf2ser')
+            offsets     = List(Int, [1, 2, 3, 4])
+            names       = List(Str, ['joe', 'fred', 'jane'])
 
         helper = AcmeUIPreferencesHelper()
         self.assertEqual(u'U\xdc\xf2ser', helper.description)
@@ -220,6 +226,11 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         helper.description = u'caf\xe9'
         self.assertEqual(u'caf\xe9', helper.description)
+        self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
+
+        p.save(self.example)
+
+        p.load(self.example)
         self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
 
     def test_no_preferences_path(self):

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -204,6 +204,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
         """ default values """
 
         p = self.preferences
+        p.load(self.example)
 
         class AcmeUIPreferencesHelper(PreferencesHelper):
             """ A helper! """
@@ -221,6 +222,9 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names       = List(Str, ['joe', 'fred', 'jane'])
 
         helper = AcmeUIPreferencesHelper()
+
+        original_description = helper.description
+        helper.description = u'U\xdc\xf2ser'
         self.assertEqual(u'U\xdc\xf2ser', helper.description)
 
 
@@ -232,6 +236,12 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         p.load(self.example)
         self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
+        self.assertEqual(u'True', p.get('acme.ui.visible'))
+        self.assertEqual(True, helper.visible)
+
+        # reset the original description and save the example file
+        helper.description = original_description
+        p.save(self.example)
 
     def test_no_preferences_path(self):
         """ no preferences path """

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -200,7 +200,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         return
 
-   def test_real_unicode_values(self):
+    def test_real_unicode_values(self):
         """ default values """
 
         p = self.preferences
@@ -218,12 +218,9 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual(u'U\xdc\xf2ser', helper.description)
 
 
-        p = Preferences()
-        p.load(self.example)
-        p.set('acme.ui.description', u'caf\xe9')
-
+        helper.description = u'caf\xe9'
         self.assertEqual(u'caf\xe9', helper.description)
-
+        self.assertEqual('caf\xc3\xa9', p.get('acme.ui.description'))
 
     def test_no_preferences_path(self):
         """ no preferences path """

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -212,10 +212,18 @@ class PreferencesHelperTestCase(unittest.TestCase):
             preferences_path = 'acme.ui'
 
             # The traits that we want to initialize from preferences.
-            description = Unicode(u'FreeU\xdc\xf2ser')
+            description = Unicode(u'U\xdc\xf2ser')
 
         helper = AcmeUIPreferencesHelper()
-        self.assertEqualu'FreeU\xdc\xf2ser', helper.description)
+        self.assertEqual(u'U\xdc\xf2ser', helper.description)
+
+
+        p = Preferences()
+        p.load(self.example)
+        p.set('acme.ui.description', u'caf\xe9')
+
+        self.assertEqual(u'caf\xe9', helper.description)
+
 
     def test_no_preferences_path(self):
         """ no preferences path """

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -200,6 +200,23 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         return
 
+   def test_real_unicode_values(self):
+        """ default values """
+
+        p = self.preferences
+
+        class AcmeUIPreferencesHelper(PreferencesHelper):
+            """ A helper! """
+
+            # The path to the preferences node that contains our preferences.
+            preferences_path = 'acme.ui'
+
+            # The traits that we want to initialize from preferences.
+            description = Unicode(u'FreeU\xdc\xf2ser')
+
+        helper = AcmeUIPreferencesHelper()
+        self.assertEqualu'FreeU\xdc\xf2ser', helper.description)
+
     def test_no_preferences_path(self):
         """ no preferences path """
 


### PR DESCRIPTION
The PreferencesHelper don't work properly when getting/storing unicode strings with non-ascii caracters. This PR intends to fix the issue.