### PR TITLE
Use a full unicode layer in preferences.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Enhancements
 
 * Apptools now have a changelog!
 * Preferences system defaults to utf-8 encoded string with ConfigObj providing
-  better support for unicode in the PreferenceHelper (#41).
+  better support for unicode in the PreferenceHelper (#45).
 * Added a traitsified backport of Python 3's lru_cache (#39).
 * Added PyTables support to the io submodule (#19, #20, and #24 through #34).
 * Added a SelectionService for managing selections within an application (#15, #16, #17,

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,20 @@
+Apptools CHANGELOG
+==================
+
+Change summary since 4.2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enhancements
+
+ * Apptools now have a changelog!
+ * Preferences system defaults to utf-8 encoded string with ConfigObj providing
+   better support for unicode in the PreferenceHelper (#41).
+
+Changes
+
+ * 
+
+Fixes
+
+ * 
+

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -541,6 +541,14 @@ class Preferences(HasTraits):
 
     def _set(self, key, value):
         """ Set the value of a preference in this node. """
+        
+        # everything must be unicode encoded so that ConfigObj configuration
+        # can properly serialize the data. If we receive regular str, they are
+        # supposed to be utf-8 encoded
+        if isinstance(value, str):
+            value = value.decode('utf-8')
+        else:
+            value = unicode(value)
 
         self._lk.acquire()
         old = self._preferences.get(key)

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -543,12 +543,9 @@ class Preferences(HasTraits):
         """ Set the value of a preference in this node. """
         
         # everything must be unicode encoded so that ConfigObj configuration
-        # can properly serialize the data. If we receive regular str, they are
-        # supposed to be utf-8 encoded
-        if isinstance(value, str):
-            value = value.decode('utf-8')
-        else:
-            value = unicode(value)
+        # can properly serialize the data. Python str are supposed to be ASCII
+        # encoded.
+        value = unicode(value)
 
         self._lk.acquire()
         old = self._preferences.get(key)

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -130,12 +130,13 @@ class PreferencesHelper(HasTraits):
 
         # If the trait type is 'Str' then we just take the raw value.
         if isinstance(handler, Str) or trait.is_str:
-            pass
+            # Just in case we get back a unicode object, convert it to a
+            # utf-8 encoded object.
+            value = value.encode('utf-8')
 
         elif isinstance(handler, Unicode):
-            # Just in case we get back an ASCII `str` object, convert it to a
-            # `unicode` object.     
-            value = unicode(value) 
+   
+            pass
 
         # Otherwise, we eval it!
         else:

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -128,14 +128,8 @@ class PreferencesHelper(HasTraits):
         trait = self.trait(trait_name)
         handler = trait.handler
 
-        # If the trait type is 'Str' then we just take the raw value.
-        if isinstance(handler, Str) or trait.is_str:
-            # Just in case we get back a unicode object, convert it to a
-            # utf-8 encoded object.
-            value = value.encode('utf-8')
-
-        elif isinstance(handler, Unicode):
-   
+        # If the trait type is 'Str' or Unicode then we just take the raw value.
+        if isinstance(handler, (Str, Unicode)) or trait.is_str:
             pass
 
         # Otherwise, we eval it!

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -201,7 +201,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
         return
 
     def test_real_unicode_values(self):
-        """ default values """
+        """ Test with real life unicode values """
 
         p = self.preferences
         p.load(self.example)
@@ -217,25 +217,30 @@ class PreferencesHelperTestCase(unittest.TestCase):
             width       = Int(50)
             ratio       = Float(1.0)
             visible     = Bool(True)
-            description = Unicode(u'U\xdc\xf2ser')
+            description = Unicode(u'')
             offsets     = List(Int, [1, 2, 3, 4])
             names       = List(Str, ['joe', 'fred', 'jane'])
 
         helper = AcmeUIPreferencesHelper()
 
+        first_unicode_str = u'U\xdc\xf2ser'
+        first_utf8_str = 'U\xc3\x9c\xc3\xb2ser'
+
         original_description = helper.description
-        helper.description = u'U\xdc\xf2ser'
-        self.assertEqual(u'U\xdc\xf2ser', helper.description)
+        helper.description = first_unicode_str
+        self.assertEqual(first_unicode_str, helper.description)
 
 
-        helper.description = u'caf\xe9'
-        self.assertEqual(u'caf\xe9', helper.description)
-        self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
+        second_unicode_str = u'caf\xe9'
+        second_utf8_str = 'caf\xc3\xa9'
+        helper.description = second_unicode_str
+        self.assertEqual(second_unicode_str, helper.description)
+        self.assertEqual(second_unicode_str, p.get('acme.ui.description'))
 
         p.save(self.example)
 
         p.load(self.example)
-        self.assertEqual(u'caf\xe9', p.get('acme.ui.description'))
+        self.assertEqual(second_unicode_str, p.get('acme.ui.description'))
         self.assertEqual(u'True', p.get('acme.ui.visible'))
         self.assertEqual(True, helper.visible)
 
@@ -496,11 +501,11 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # ratio to get set via the static trait change handler on the helper.
         p.set('acme.ui.width', 42)
         self.assertEqual(42, helper.width)
-        self.assertEqual(42, p.get('acme.ui.width'))
+        self.assertEqual('42', p.get('acme.ui.width'))
 
         # Did the ratio get changed?
         self.assertEqual(3.0, helper.ratio)
-        self.assertEqual(3.0, p.get('acme.ui.ratio'))
+        self.assertEqual('3.0', p.get('acme.ui.ratio'))
 
         return
 


### PR DESCRIPTION
PR #41 was changing the behaviour of the Preference class by not converting object to str anymore. This caused a clear problem when getting preferences from a file as the same call to retrieve a preference could either return a specific type or a unicode object as read by ConfigObj in the file.  

This PR changes the behaviour again and gets back to the original design of Preferences which standardizes on str objects. When setting an object in the Preference class it is automatically converted to a unicode object (defaulting to utf-8 encoded strings as input), the unicode object is then properly serialized as utff-8 str by ConfigObj when saving the prefence to a file. When loading the preference in the preference helper, the object is nicely converted back to its target type, with `Str` as a special case where the unicode object is encoded to a utf-8 str)

This PR fixes the broken test suite.

@corranwebster Can you review? @rkern this changes a bit what we talked about in #41 but is probably the least painful implementation before switching to a better storage like yaml. 