### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ addons:
     - ccache
     - swig
     - libhdf5-serial-dev
-matrix:
- allow_failures:
-    - python: 3.4
 cache:
   apt: true
   directories:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Apptools CHANGELOG
 ==================
 
+Version 4.4.0
+~~~~~~~~~~~~~
+
+* Apptools now works with Python-3.x. (#54)
+* Travis-ci support with testing on Python 2.6, 2.7 and 3.4. (#55)
+
+
 Change summary since 4.2.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/apptools/appscripting/bind_event.py
+++ b/apptools/appscripting/bind_event.py
@@ -14,16 +14,17 @@
 
 
 # Enthought library imports.
-from traits.api import Any, HasTraits, implements, Str
+from traits.api import Any, HasTraits, provides, Str
 
 # Local imports.
 from i_bind_event import IBindEvent
 
 
+@provides(IBindEvent)
 class BindEvent(HasTraits):
     """The default implementation of the bind event interface."""
 
-    implements(IBindEvent)
+
 
     #### 'IBindEvent' interface ###############################################
 

--- a/apptools/appscripting/script_manager.py
+++ b/apptools/appscripting/script_manager.py
@@ -30,6 +30,7 @@ from lazy_namespace import add_to_namespace, FactoryWrapper, LazyNamespace
 from scriptable_type import make_object_scriptable
 
 
+@provides(IScriptManager)
 class _BoundObject(HasTraits):
     """The base class for any object that can be bound to a name."""
 
@@ -294,7 +295,7 @@ class ScriptManager(HasTraits):
     IScriptManager.
     """
 
-    implements(IScriptManager)
+
 
     #### 'IScriptManager' interface ###########################################
 

--- a/apptools/help/help_plugin/action/demo_action.py
+++ b/apptools/help/help_plugin/action/demo_action.py
@@ -19,7 +19,7 @@ import sys
 # Enthought library imports.
 from envisage.api import IExtensionPointUser, IExtensionRegistry
 from pyface.workbench.action.workbench_action import WorkbenchAction
-from traits.api import Instance, implements, Property
+from traits.api import Instance, provides, Property
 from pyface.api import ImageResource
 from apptools.help.help_plugin.api import HelpCode
 
@@ -32,6 +32,7 @@ PARENT = '.'.join(__name__.split('.')[:-2])
 from util import get_sys_prefix_relative_filename
 
 # Implementation of the ImageResource class to be used for the DocAction class.
+@provides(IExtensionPointUser)
 class DemoImageResource(ImageResource):
     """ Implementation of the ImageResource class to be used for the DemoAction
     class.
@@ -44,7 +45,7 @@ class DemoImageResource(ImageResource):
 class DemoAction(WorkbenchAction):
     """
     """
-    implements(IExtensionPointUser)
+
 
     ### Action interface ##############################################
 

--- a/apptools/help/help_plugin/action/doc_action.py
+++ b/apptools/help/help_plugin/action/doc_action.py
@@ -20,7 +20,7 @@ import sys
 # Enthought library imports.
 from envisage.api import IExtensionPointUser, IExtensionRegistry
 from pyface.workbench.action.workbench_action import WorkbenchAction
-from traits.api import Instance, implements, Property
+from traits.api import Instance, provides, Property
 from pyface.api import ImageResource
 
 from apptools.help.help_plugin.api import HelpDoc
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 PARENT = '.'.join(__name__.split('.')[:-2])
 
 # Implementation of the ImageResource class to be used for the DocAction class.
+@provides(IExtensionPointUser)
 class DocImageResource(ImageResource):
     """ Implementation of the ImageResource class to be used for the DocAction
     class.
@@ -46,7 +47,7 @@ class DocImageResource(ImageResource):
 class DocAction(WorkbenchAction):
     """ (Pyface) Action for displaying a help doc.
     """
-    implements(IExtensionPointUser)
+
 
     ### Action interface ##############################################
 

--- a/apptools/help/help_plugin/action/example_action.py
+++ b/apptools/help/help_plugin/action/example_action.py
@@ -18,7 +18,7 @@ from subprocess import Popen
 # Enthought library imports.
 from envisage.api import IExtensionPointUser, IExtensionRegistry
 from pyface.workbench.action.workbench_action import WorkbenchAction
-from traits.api import Instance, implements, Property
+from traits.api import Instance, provides, Property
 
 from apptools.help.help_plugin.api import HelpCode
 from apptools.help.help_plugin.examples_preferences import \
@@ -33,10 +33,11 @@ logger = logging.getLogger(__name__)
 # This module's parent package.
 PARENT = '.'.join(__name__.split('.')[:-2])
 
+@provides(IExtensionPointUser)
 class ExampleAction(WorkbenchAction):
     """ (Pyface) Action for displaying a help example.
     """
-    implements(IExtensionPointUser)
+
 
     ### IExtensionPointUser interface
     extension_registry = Property(Instance(IExtensionRegistry))

--- a/apptools/help/help_plugin/examples_preferences.py
+++ b/apptools/help/help_plugin/examples_preferences.py
@@ -12,7 +12,7 @@
 
 
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Either, Enum, File, Str, implements
+from traits.api import Either, Enum, File, Str, provides
 
 # This module's package.
 PKG = '.'.join(__name__.split('.')[:-1])

--- a/apptools/help/help_plugin/help_code.py
+++ b/apptools/help/help_plugin/help_code.py
@@ -13,16 +13,17 @@
 # Thanks for using Enthought open source!
 
 from apptools.preferences.api import PreferencesHelper
-from traits.api import File, Str, implements
+from traits.api import File, Str, provides
 
 from i_help_code import IHelpCode
 
+@provides(IHelpCode)
 class HelpCode(PreferencesHelper):
     """ The implementation for help codes.
 
     A help code is defined by a UI label and a filename.
     """
-    implements(IHelpCode)
+
 
     #### IHelpCode interface / Preferences #####################################
 

--- a/apptools/help/help_plugin/help_doc.py
+++ b/apptools/help/help_plugin/help_doc.py
@@ -11,16 +11,17 @@
 # Thanks for using Enthought open source!
 
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Either, File, Str, implements, Bool
+from traits.api import Either, File, Str, provides, Bool
 
 from i_help_doc import IHelpDoc
 
+@provides(IHelpDoc)
 class HelpDoc(PreferencesHelper):
     """ The implementation for help docs.
 
     A help doc is defined by a UI label, a filename, and a viewer program.
     """
-    implements(IHelpDoc)
+
 
     #### IHelpDoc interface / Preferences ######################################
 

--- a/apptools/help/help_plugin/help_submenu_manager.py
+++ b/apptools/help/help_plugin/help_submenu_manager.py
@@ -17,7 +17,7 @@ import logging
 # Enthought library imports.
 from envisage.api import IExtensionPointUser, IExtensionRegistry
 from pyface.action.api import Group, MenuManager
-from traits.api import Any, implements, Instance, List, Property
+from traits.api import Any, provides, Instance, List, Property
 
 # Local imports.
 from action.doc_action import DocAction
@@ -34,13 +34,14 @@ logger = logging.getLogger(__name__)
 # This module's package.
 PKG = '.'.join(__name__.split('.')[:-1])
 
+@provides(IExtensionPointUser)
 class HelpSubmenuManager(MenuManager):
     """ Base class for managers of submenus of the Help menu.
 
         This class is adapted from
         pyface.ui.workbench.action.view_menu_manager.ViewMenuManager.
     """
-    implements(IExtensionPointUser)
+
 
     ### IExtensionPointUser interface
     extension_registry = Property(Instance(IExtensionRegistry))

--- a/apptools/io/file.py
+++ b/apptools/io/file.py
@@ -227,7 +227,7 @@ class File(HasPrivateTraits):
         if self.exists:
             raise ValueError("file %s already exists" % self.path)
 
-        f = file(self.path, 'w')
+        f = open(self.path, 'w')
         f.write(contents)
         f.close()
 

--- a/apptools/io/h5/dict_node.py
+++ b/apptools/io/h5/dict_node.py
@@ -44,7 +44,9 @@ class H5DictNode(object):
         # Load dict data from the file node.
         dict_node = getattr(h5_group, self._pyobject_data_node)
         with closing(filenode.open_node(dict_node)) as f:
-            self._pyobject_data = json.load(f, object_hook=self._object_hook)
+            self._pyobject_data = json.loads(
+                f.read().decode('ascii'), object_hook=self._object_hook
+            )
 
     #--------------------------------------------------------------------------
     #  Dictionary interface
@@ -172,7 +174,7 @@ class H5DictNode(object):
 
         kwargs = dict(where=node_path, name=cls._pyobject_data_node)
         with closing(filenode.new_node(pyt_file, **kwargs)) as f:
-            json.dump(out_data, f)
+            f.write(json.dumps(out_data).encode('ascii'))
 
     @classmethod
     def _get_pyt_group(self, group):

--- a/apptools/io/h5/tests/test_file.py
+++ b/apptools/io/h5/tests/test_file.py
@@ -86,7 +86,10 @@ def test_iteritems():
         node_paths.append('/')
         iter_paths = []
 
-        for path, node in h5.iteritems():
+        # 2to3 converts the iteritems blindly to items which is incorrect,
+        # so we resort to this ugliness.
+        items = getattr(h5, 'iteritems')()
+        for path, node in items:
             iter_paths.append(path)
 
     assert set(node_paths) == set(iter_paths)

--- a/apptools/io/h5/tests/test_table_node.py
+++ b/apptools/io/h5/tests/test_table_node.py
@@ -42,7 +42,7 @@ def test_getitem():
 def test_keys():
     description = [('hello', 'int'), ('world', 'int'), ('Qux1', 'bool')]
     with temp_h5_file() as h5:
-        keys = set(zip(*description)[0])
+        keys = set(list(zip(*description))[0])
         h5table = H5TableNode.add_to_h5file(h5, NODE, description)
         assert set(h5table.keys()) == keys
 

--- a/apptools/io/tests/file_test_case.py
+++ b/apptools/io/tests/file_test_case.py
@@ -161,7 +161,7 @@ class FileTestCase(unittest.TestCase):
         # Create the file.
         f.create_file(content)
         self.assertEqual(f.exists, True)
-        self.assertEqual(file(f.path).read(), content)
+        self.assertEqual(open(f.path).read(), content)
 
         # Try to create it again.
         self.assertRaises(ValueError, f.create_file, content)

--- a/apptools/io/tests/file_test_case.py
+++ b/apptools/io/tests/file_test_case.py
@@ -113,7 +113,7 @@ class FileTestCase(unittest.TestCase):
         # Create the file.
         f.create_file(content)
         self.assertEqual(f.exists, True)
-        self.failUnlessRaises(ValueError, f.create_file, content)
+        self.assertRaises(ValueError, f.create_file, content)
 
         self.assertEqual(f.children, None)
         self.assertEqual(f.ext, '.txt')
@@ -164,7 +164,7 @@ class FileTestCase(unittest.TestCase):
         self.assertEqual(file(f.path).read(), content)
 
         # Try to create it again.
-        self.failUnlessRaises(ValueError, f.create_file, content)
+        self.assertRaises(ValueError, f.create_file, content)
 
         return
 
@@ -179,7 +179,7 @@ class FileTestCase(unittest.TestCase):
         # Create the file.
         f.create_file(content)
         self.assertEqual(f.exists, True)
-        self.failUnlessRaises(ValueError, f.create_file, content)
+        self.assertRaises(ValueError, f.create_file, content)
 
         self.assertEqual(f.children, None)
         self.assertEqual(f.ext, '.txt')

--- a/apptools/io/tests/folder_test_case.py
+++ b/apptools/io/tests/folder_test_case.py
@@ -133,7 +133,7 @@ class FolderTestCase(unittest.TestCase):
         # Create the folder.
         f.create_folder()
         self.assertEqual(f.exists, True)
-        self.failUnlessRaises(ValueError, f.create_folder)
+        self.assertRaises(ValueError, f.create_folder)
 
         self.assertEqual(len(f.children), 0)
         self.assertEqual(f.ext, '')
@@ -185,7 +185,7 @@ class FolderTestCase(unittest.TestCase):
         self.assertEqual(parent.children[0].path, join('data', 'sub'))
 
         # Try to create it again.
-        self.failUnlessRaises(ValueError, f.create_folder)
+        self.assertRaises(ValueError, f.create_folder)
 
         return
 
@@ -197,7 +197,7 @@ class FolderTestCase(unittest.TestCase):
 
         # Attempt to create the folder with 'create_folder' which requires
         # that all intermediate folders exist.
-        self.failUnlessRaises(OSError, f.create_folder)
+        self.assertRaises(OSError, f.create_folder)
 
         # Create the folder.
         f.create_folders()
@@ -205,7 +205,7 @@ class FolderTestCase(unittest.TestCase):
         self.assertEqual(File('data/sub').exists, True)
 
         # Try to create it again.
-        self.failUnlessRaises(ValueError, f.create_folders)
+        self.assertRaises(ValueError, f.create_folders)
 
         return
 
@@ -218,7 +218,7 @@ class FolderTestCase(unittest.TestCase):
         # Create the folder.
         f.create_folder()
         self.assertEqual(f.exists, True)
-        self.failUnlessRaises(ValueError, f.create_folder)
+        self.assertRaises(ValueError, f.create_folder)
 
         self.assertEqual(len(f.children), 0)
         self.assertEqual(f.ext, '')

--- a/apptools/naming/object_serializer.py
+++ b/apptools/naming/object_serializer.py
@@ -53,7 +53,7 @@ class ObjectSerializer(HasTraits):
         """ Loads an object from a file. """
 
         # Unpickle the object.
-        f = file(path, 'rb')
+        f = open(path, 'rb')
         try:
             try:
                  obj = sweet_pickle.load(f)
@@ -84,7 +84,7 @@ class ObjectSerializer(HasTraits):
             actual_path = path
 
         # Pickle the object.
-        f = file(actual_path, 'wb')
+        f = open(actual_path, 'wb')
         try:
             sweet_pickle.dump(obj, f, 1)
 #            cPickle.dump(obj, f, 1)

--- a/apptools/naming/py_context.py
+++ b/apptools/naming/py_context.py
@@ -102,7 +102,7 @@ class PyContext(Context, Referenceable):
     def _is_bound(self, name):
         """ Is a name bound in this context? """
 
-        return self.namespace.has_key(name)
+        return name in self.namespace
 
     def _lookup(self, name):
         """ Looks up a name in this context. """

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -508,7 +508,7 @@ class PyFSContext(DirContext, Referenceable):
 
         path = join(self.path, self.ATTRIBUTES_FILE)
 
-        f = file(path, 'wb')
+        f = open(path, 'wb')
         cPickle.dump(self._attributes, f, 1)
         f.close()
 
@@ -552,7 +552,7 @@ class PyFSContext(DirContext, Referenceable):
 
         attributes_file = File(join(self.path, self.ATTRIBUTES_FILE))
         if attributes_file.is_file:
-            f = file(attributes_file.path, 'rb')
+            f = open(attributes_file.path, 'rb')
             attributes = cPickle.load(f)
             f.close()
 

--- a/apptools/naming/tests/context_test_case.py
+++ b/apptools/naming/tests/context_test_case.py
@@ -68,10 +68,10 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.bind, '', 1)
+        self.assertRaises(InvalidNameError, context.bind, '', 1)
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.bind, 'xx/a', 1)
+        self.assertRaises(NameNotFoundError, context.bind, 'xx/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -79,11 +79,11 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(NotContextError, context.bind, 'sub/a/xx', 1)
+        self.assertRaises(NotContextError, context.bind, 'sub/a/xx', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Try to bind it again.
-        self.failUnlessRaises(NameAlreadyBoundError, context.bind, 'sub/a', 1)
+        self.assertRaises(NameAlreadyBoundError, context.bind, 'sub/a', 1)
 
         return
 
@@ -99,7 +99,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.bind, '', 1, True)
+        self.assertRaises(InvalidNameError, context.bind, '', 1, True)
 
         # Attempt to resolve via a non-existent context - which should result
         # in the context being created automatically.
@@ -125,10 +125,10 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rebind, '', 1)
+        self.assertRaises(InvalidNameError, context.rebind, '', 1)
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.rebind, 'xx/a', 1)
+        self.assertRaises(NameNotFoundError, context.rebind, 'xx/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -140,7 +140,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(NotContextError, context.rebind, 'sub/a/xx', 1)
+        self.assertRaises(NotContextError, context.rebind, 'sub/a/xx', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         return
@@ -157,7 +157,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rebind, '', 1, True)
+        self.assertRaises(InvalidNameError, context.rebind, '', 1, True)
 
         # Attempt to resolve via a non-existent context - which should result
         # in the context being created automatically.
@@ -188,10 +188,10 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.unbind, '')
+        self.assertRaises(InvalidNameError, context.unbind, '')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.unbind, 'xx/a')
+        self.assertRaises(NameNotFoundError, context.unbind, 'xx/a')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -199,7 +199,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(NotContextError, context.unbind, 'sub/a/xx')
+        self.assertRaises(NotContextError, context.unbind, 'sub/a/xx')
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Unbind it.
@@ -207,7 +207,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Try to unbind a non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.unbind, 'sub/b')
+        self.assertRaises(NameNotFoundError, context.unbind, 'sub/b')
 
         return
 
@@ -222,11 +222,11 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rename, '', 'x')
-        self.failUnlessRaises(InvalidNameError, context.rename, 'x', '')
+        self.assertRaises(InvalidNameError, context.rename, '', 'x')
+        self.assertRaises(InvalidNameError, context.rename, 'x', '')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.rename, 'x/a', 'x/b')
+        self.assertRaises(NameNotFoundError, context.rename, 'x/a', 'x/b')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -234,7 +234,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(NotContextError, context.bind, 'sub/a/xx', 1)
+        self.assertRaises(NotContextError, context.bind, 'sub/a/xx', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Rename it.
@@ -245,7 +245,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(context.lookup('sub/b'), 1)
 
         # Lookup using the old name.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'sub/a')
+        self.assertRaises(NameNotFoundError, context.lookup, 'sub/a')
 
         return
 
@@ -260,11 +260,11 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rename, '', 'x')
-        self.failUnlessRaises(InvalidNameError, context.rename, 'x', '')
+        self.assertRaises(InvalidNameError, context.rename, '', 'x')
+        self.assertRaises(InvalidNameError, context.rename, 'x', '')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.rename, 'x/a', 'x/b')
+        self.assertRaises(NameNotFoundError, context.rename, 'x/a', 'x/b')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Create a context.
@@ -279,7 +279,7 @@ class ContextTestCase(unittest.TestCase):
         context.lookup('sub/b')
 
         # Lookup using the old name.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'sub/a')
+        self.assertRaises(NameNotFoundError, context.lookup, 'sub/a')
 
         return
 
@@ -294,7 +294,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'xx/a')
+        self.assertRaises(NameNotFoundError, context.lookup, 'xx/a')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -302,7 +302,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(NotContextError, context.lookup, 'sub/a/xx')
+        self.assertRaises(NotContextError, context.lookup, 'sub/a/xx')
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Look it up.
@@ -312,7 +312,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(context.lookup(''), context)
 
         # Non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'sub/b')
+        self.assertRaises(NameNotFoundError, context.lookup, 'sub/b')
 
         return
 
@@ -327,10 +327,10 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.create_subcontext, '')
+        self.assertRaises(InvalidNameError, context.create_subcontext, '')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.create_subcontext, 'xx/a'
         )
         self.assertEqual(len(sub.list_bindings('')), 0)
@@ -340,7 +340,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Try to bind it again.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameAlreadyBoundError, context.create_subcontext, 'sub/a'
         )
 
@@ -349,7 +349,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 2)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.create_subcontext, 'sub/b/xx'
         )
         self.assertEqual(len(sub.list_bindings('')), 2)
@@ -367,10 +367,10 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.destroy_subcontext, '')
+        self.assertRaises(InvalidNameError, context.destroy_subcontext, '')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.destroy_subcontext, 'xx/a'
         )
         self.assertEqual(len(sub.list_bindings('')), 0)
@@ -388,17 +388,17 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Try to destroy it.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.destroy_subcontext, 'sub/a'
         )
 
         # Try to destroy a non-existent name.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.destroy_subcontext, 'sub/b'
         )
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.destroy_subcontext, 'sub/a/xx'
         )
         self.assertEqual(len(sub.list_bindings('')), 1)
@@ -421,7 +421,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(bindings), 0)
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.list_bindings, 'xx/a')
+        self.assertRaises(NameNotFoundError, context.list_bindings, 'xx/a')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -429,7 +429,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.list_bindings, 'sub/a/xx'
         )
         self.assertEqual(len(sub.list_bindings('')), 1)
@@ -452,7 +452,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(names), 0)
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.list_names, 'xx/a')
+        self.assertRaises(NameNotFoundError, context.list_names, 'xx/a')
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Bind a name.
@@ -460,7 +460,7 @@ class ContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Attempt to resolve via an existing name that is not a context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.list_names, 'sub/a/xx'
         )
         self.assertEqual(len(sub.list_bindings('')), 1)
@@ -471,12 +471,12 @@ class ContextTestCase(unittest.TestCase):
         """ default object and state factories. """
 
         object_factory = ObjectFactory()
-        self.failUnlessRaises(
+        self.assertRaises(
             NotImplementedError, object_factory.get_object_instance, 0, 0, 0
         )
 
         state_factory = StateFactory()
-        self.failUnlessRaises(
+        self.assertRaises(
             NotImplementedError, state_factory.get_state_to_bind, 0, 0, 0
         )
 

--- a/apptools/naming/tests/context_test_case.py
+++ b/apptools/naming/tests/context_test_case.py
@@ -511,7 +511,7 @@ class ContextTestCase(unittest.TestCase):
         context.bind('sub/sub sub/one',1)
         names = context.search( 1 )
         self.assertEqual( len(names), 2)
-        self.assertEqual( names, ['one', 'sub/sub sub/one'] )
+        self.assertEqual( sorted(names), sorted(['one', 'sub/sub sub/one']) )
 
         names = sub.search(None)
         self.assertEqual( len(names), 0)

--- a/apptools/naming/tests/dir_context_test_case.py
+++ b/apptools/naming/tests/dir_context_test_case.py
@@ -48,15 +48,15 @@ class DirContextTestCase(ContextTestCase):
         #### Generic name resolution tests ####
 
         # Non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.get_attributes, 'x')
+        self.assertRaises(NameNotFoundError, context.get_attributes, 'x')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.get_attributes, 'x/a')
+        self.assertRaises(NameNotFoundError, context.get_attributes, 'x/a')
 
         # Attempt to resolve via an existing name that is not a context.
         context.bind('sub/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
-        self.failUnlessRaises(NotContextError,context.get_attributes,'sub/a/x')
+        self.assertRaises(NotContextError,context.get_attributes,'sub/a/x')
 
         #### Operation specific tests ####
 
@@ -83,19 +83,19 @@ class DirContextTestCase(ContextTestCase):
         #### Generic name resolution tests ####
 
         # Non-existent name.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.set_attributes, 'x', defaults
         )
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.set_attributes, 'x/a', defaults
         )
 
         # Attempt to resolve via an existing name that is not a context.
         context.bind('sub/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.set_attributes, 'sub/a/xx', defaults
         )
 

--- a/apptools/naming/tests/pyfs_context_test_case.py
+++ b/apptools/naming/tests/pyfs_context_test_case.py
@@ -90,7 +90,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.bind, '', 1)
+        self.assertRaises(InvalidNameError, context.bind, '', 1)
 
         # Bind a local file object.
         f = File(os.path.join(sub.path, 'foo.py'))
@@ -116,7 +116,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 4)
 
         # Try to bind it again.
-        self.failUnlessRaises(NameAlreadyBoundError, context.bind, 'sub/a', 1)
+        self.assertRaises(NameAlreadyBoundError, context.bind, 'sub/a', 1)
 
         return
 
@@ -131,7 +131,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rebind, '', 1)
+        self.assertRaises(InvalidNameError, context.rebind, '', 1)
 
         # Bind a name.
         context.bind('sub/a', 1)
@@ -154,7 +154,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.unbind, '')
+        self.assertRaises(InvalidNameError, context.unbind, '')
 
         # Bind a name.
         context.bind('sub/a', 1)
@@ -165,7 +165,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Try to unbind a non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.unbind, 'sub/b')
+        self.assertRaises(NameNotFoundError, context.unbind, 'sub/b')
 
         return
 
@@ -180,8 +180,8 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.rename, '', 'x')
-        self.failUnlessRaises(InvalidNameError, context.rename, 'x', '')
+        self.assertRaises(InvalidNameError, context.rename, '', 'x')
+        self.assertRaises(InvalidNameError, context.rename, 'x', '')
 
         # Bind a name.
         context.bind('sub/a', 1)
@@ -195,7 +195,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(context.lookup('sub/b'), 1)
 
         # Lookup using the old name.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'sub/a')
+        self.assertRaises(NameNotFoundError, context.lookup, 'sub/a')
 
     def test_lookup(self):
         """ pyfs context lookup """
@@ -228,7 +228,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(context.lookup(''), context)
 
         # Non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.lookup, 'sub/b')
+        self.assertRaises(NameNotFoundError, context.lookup, 'sub/b')
 
         return
 
@@ -243,7 +243,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.create_subcontext, '')
+        self.assertRaises(InvalidNameError, context.create_subcontext, '')
 
         # Create a sub-context.
         a = context.create_subcontext('sub/a')
@@ -251,7 +251,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assert_(os.path.isdir(os.path.join(sub.path, 'a')))
 
         # Try to bind it again.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameAlreadyBoundError, context.create_subcontext, 'sub/a'
         )
 
@@ -268,7 +268,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 0)
 
         # Empty name.
-        self.failUnlessRaises(InvalidNameError, context.destroy_subcontext, '')
+        self.assertRaises(InvalidNameError, context.destroy_subcontext, '')
 
         # Create a sub-context.
         a = context.create_subcontext('sub/a')
@@ -284,14 +284,14 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertEqual(len(sub.list_bindings('')), 1)
 
         # Try to destroy it.
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.destroy_subcontext, 'sub/a'
         )
 
         return
 
         # Try to destroy a non-existent name.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.destroy_subcontext, 'sub/b'
         )
 
@@ -308,15 +308,15 @@ class PyFSContextTestCase(unittest.TestCase):
         #### Generic name resolution tests ####
 
         # Non-existent name.
-        self.failUnlessRaises(NameNotFoundError, context.get_attributes, 'xx')
+        self.assertRaises(NameNotFoundError, context.get_attributes, 'xx')
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(NameNotFoundError, context.get_attributes,'xx/a')
+        self.assertRaises(NameNotFoundError, context.get_attributes,'xx/a')
 
         # Attempt to resolve via an existing name that is not a context.
         context.bind('sub/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
-        self.failUnlessRaises(NotContextError,context.get_attributes,'sub/a/x')
+        self.assertRaises(NotContextError,context.get_attributes,'sub/a/x')
 
         #### Operation specific tests ####
 
@@ -343,19 +343,19 @@ class PyFSContextTestCase(unittest.TestCase):
         #### Generic name resolution tests ####
 
         # Non-existent name.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.set_attributes, 'xx', defaults
         )
 
         # Attempt to resolve via a non-existent context.
-        self.failUnlessRaises(
+        self.assertRaises(
             NameNotFoundError, context.set_attributes, 'xx/a', defaults
         )
 
         # Attempt to resolve via an existing name that is not a context.
         context.bind('sub/a', 1)
         self.assertEqual(len(sub.list_bindings('')), 1)
-        self.failUnlessRaises(
+        self.assertRaises(
             NotContextError, context.set_attributes, 'sub/a/xx', defaults
         )
 

--- a/apptools/permissions/default/policy_manager.py
+++ b/apptools/permissions/default/policy_manager.py
@@ -16,7 +16,7 @@
 # Enthought library imports.
 from pyface.api import error
 from pyface.action.api import Action
-from traits.api import Dict, HasTraits, implements, Instance, List
+from traits.api import Dict, HasTraits, provides, Instance, List
 
 # Local imports.
 from apptools.permissions.i_policy_manager import IPolicyManager
@@ -27,12 +27,13 @@ from role_assignment import role_assignment
 from role_definition import role_definition
 
 
+@provides(IPolicyManager)
 class PolicyManager(HasTraits):
     """The default policy manager implementation.  This policy enforces the use
     of roles.  Permissions are associated with roles rather than directly with
     users.  Users are then associated with one or more roles."""
 
-    implements(IPolicyManager)
+
 
     #### 'IPolicyManager' interface ###########################################
 

--- a/apptools/permissions/default/policy_storage.py
+++ b/apptools/permissions/default/policy_storage.py
@@ -14,18 +14,19 @@
 
 
 # Enthought library imports.
-from traits.api import HasTraits, Instance, implements
+from traits.api import HasTraits, Instance, provides
 
 # Local imports.
 from i_policy_storage import IPolicyStorage, PolicyStorageError
 from persistent import Persistent, PersistentError
 
 
+@provides(IPolicyStorage)
 class PolicyStorage(HasTraits):
     """This implements a policy database that pickles its data in a local file.
     """
 
-    implements(IPolicyStorage)
+
 
     #### Private interface ####################################################
 

--- a/apptools/permissions/default/user_database.py
+++ b/apptools/permissions/default/user_database.py
@@ -18,7 +18,7 @@ import os
 
 # Enthought library imports.
 from pyface.api import confirm, error, YES
-from traits.api import Bool, Dict, HasTraits, implements, Instance, \
+from traits.api import Bool, Dict, HasTraits, provides, Instance, \
         List, Password, Property, Unicode
 from traitsui.api import Handler, Item, View
 from traitsui.menu import Action, OKCancelButtons
@@ -30,6 +30,7 @@ from i_user_storage import IUserStorage, UserStorageError
 from select_user import select_user
 
 
+@provides(IUser)
 class _LoginUser(HasTraits):
     """This represents the login data and view."""
 
@@ -244,7 +245,7 @@ class User(HasTraits):
     """The user implementation.  We don't store any extra information other
     than that defined by IUser."""
 
-    implements(IUser)
+
 
     #### 'IUser' interface ####################################################
 
@@ -257,12 +258,13 @@ class User(HasTraits):
     blob = Dict
 
 
+@provides(IUserDatabase)
 class UserDatabase(HasTraits):
     """This implements a user database that supports IUser for the default user
     manager (ie. using password authorisation) except that it leaves the actual
     access of the data to an implementation of IUserStorage."""
 
-    implements(IUserDatabase)
+
 
     #### 'IUserDatabase' interface ############################################
 

--- a/apptools/permissions/default/user_manager.py
+++ b/apptools/permissions/default/user_manager.py
@@ -15,7 +15,7 @@
 
 # Enthought library imports.
 from pyface.action.api import Action
-from traits.api import Bool, Event, HasTraits, implements, \
+from traits.api import Bool, Event, HasTraits, provides, \
         Instance, List, Unicode
 
 # Local imports.
@@ -26,10 +26,11 @@ from apptools.permissions.permission import ManageUsersPermission
 from i_user_database import IUserDatabase
 
 
+@provides(IUserManager)
 class UserManager(HasTraits):
     """The default user manager implementation."""
 
-    implements(IUserManager)
+
 
     #### 'IUserManager' interface #############################################
 

--- a/apptools/permissions/default/user_storage.py
+++ b/apptools/permissions/default/user_storage.py
@@ -14,18 +14,19 @@
 
 
 # Enthought library imports.
-from traits.api import HasTraits, Instance, implements
+from traits.api import HasTraits, Instance, provides
 
 # Local imports.
 from i_user_storage import IUserStorage, UserStorageError
 from persistent import Persistent, PersistentError
 
 
+@provides(IUserStorage)
 class UserStorage(HasTraits):
     """This implements a user database that pickles its data in a local file.
     """
 
-    implements(IUserStorage)
+
 
     #### 'IUserStorage' interface #############################################
 

--- a/apptools/persistence/project_loader.py
+++ b/apptools/persistence/project_loader.py
@@ -20,7 +20,7 @@ def load_project(pickle_filename, updater_path, application_version, protocol,
     latest_file = pickle_filename
 
     # Read the pickled project's metadata.
-    f = file(latest_file, 'rb')
+    f = open(latest_file, 'rb')
     metadata = VersionedUnpickler(f).load(max_pass)
     f.close()
     project_version = metadata.get('version', False)
@@ -39,7 +39,7 @@ def load_project(pickle_filename, updater_path, application_version, protocol,
 
     # Finally we can import the project ...
     logger.info('loading %s' % latest_file)
-    i_f = file(latest_file, 'rb')
+    i_f = open(latest_file, 'rb')
     version = VersionedUnpickler(i_f).load(max_pass)
     project = VersionedUnpickler(i_f).load(max_pass)
     i_f.close()
@@ -70,13 +70,13 @@ def upgrade_project(pickle_filename, updater_path, project_version, application_
         next_version = project_version + 1
 
         if first_time:
-            i_f = file(pickle_filename, 'rb')
+            i_f = open(pickle_filename, 'rb')
             data = i_f.read()
             open('%s.bak' % pickle_filename, 'wb').write(data)
             i_f.seek(0) # rewind the file to the start
         else:
             name = '%s.v%d' % (pickle_filename, project_version)
-            i_f = file(name, 'rb')
+            i_f = open(name, 'rb')
             latest_file = name
 
         logger.info('converting %s' % latest_file)
@@ -100,7 +100,7 @@ def upgrade_project(pickle_filename, updater_path, project_version, application_
         # Persist the updated project ...
         name = '%s.v%d' % (pickle_filename, next_version)
         latest_file = name
-        o_f = file(name, 'wb')
+        o_f = open(name, 'wb')
         pickle.dump(project.metadata, o_f, protocol=protocol)
         pickle.dump(project, o_f, protocol=protocol)
         o_f.close()

--- a/apptools/persistence/spickle.py
+++ b/apptools/persistence/spickle.py
@@ -12,8 +12,12 @@ NOTE: This module is not likely to work for very complex pickles but
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2007, Prabhu Ramachandran
+# Copyright (c) 2006-2015, Prabhu Ramachandran
 # License: BSD Style.
+
+import sys
+if sys.version_info[0] > 2:
+    raise ImportError("This module does not work with Python 3.x")
 
 import warnings
 import pickle

--- a/apptools/persistence/spickle.py
+++ b/apptools/persistence/spickle.py
@@ -22,7 +22,7 @@ from pickle import Pickler, Unpickler, dumps, BUILD, NEWOBJ, REDUCE, \
      MARK, OBJ, INST, BUILD, PicklingError, GLOBAL, \
      EXT1, EXT2, EXT4, _extension_registry, _keep_alive
 
-from io import StringIO
+from io import BytesIO
 
 
 ######################################################################
@@ -271,7 +271,7 @@ class StateUnpickler(Unpickler):
 def get_state(obj):
     """Return a State object given an object.  Useful for testing."""
     str = dumps(obj)
-    return StateUnpickler(StringIO(str)).load()
+    return StateUnpickler(BytesIO(str)).load()
 
 def dump_state(state, file, protocol=None, bin=None):
     """Dump the state (potentially modified) to given file."""
@@ -280,7 +280,7 @@ def dump_state(state, file, protocol=None, bin=None):
 def dumps_state(state, protocol=None, bin=None):
     """Dump the state (potentially modified) to a string and return
     the string."""
-    file = StringIO()
+    file = BytesIO()
     StatePickler(file, protocol, bin).dump(state)
     return file.getvalue()
 
@@ -297,4 +297,4 @@ def load_state(file):
 def loads_state(string):
     """Loads the state from a string object.  This does not import any
     modules."""
-    return StateUnpickler(StringIO(string)).load()
+    return StateUnpickler(BytesIO(string)).load()

--- a/apptools/persistence/spickle.py
+++ b/apptools/persistence/spickle.py
@@ -19,10 +19,10 @@ import warnings
 import pickle
 import struct
 from pickle import Pickler, Unpickler, dumps, BUILD, NEWOBJ, REDUCE, \
-     MARK, OBJ, INST, BUILD, TupleType, PicklingError, GLOBAL, \
+     MARK, OBJ, INST, BUILD, PicklingError, GLOBAL, \
      EXT1, EXT2, EXT4, _extension_registry, _keep_alive
 
-from cStringIO import StringIO
+from io import StringIO
 
 
 ######################################################################
@@ -122,7 +122,7 @@ class StatePickler(Pickler):
         # This API is called by some subclasses
 
         # Assert that args is a tuple or None
-        if not isinstance(args, TupleType):
+        if not isinstance(args, tuple):
             if args is None:
                 # A hack for Jim Fulton's ExtensionClass, now deprecated.
                 # See load_reduce()
@@ -298,5 +298,3 @@ def loads_state(string):
     """Loads the state from a string object.  This does not import any
     modules."""
     return StateUnpickler(StringIO(string)).load()
-
-

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -94,7 +94,7 @@ Notes
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) 2005-2015, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.
@@ -130,7 +130,7 @@ def gunzip_string(data):
     """Given a gzipped string (`data`) this unzips the string and
     returns it.
     """
-    if bytes is not str and type(data) is bytes:
+    if PY_VER== 2 or (bytes is not str and type(data) is bytes):
         s = BytesIO(data)
     else:
         s = StringIO(data)
@@ -270,6 +270,7 @@ class StatePickler:
                     }
         if PY_VER == 2:
             type_map[long] = self._do_basic_type
+            type_map[unicode] = self._do_basic_type
         self.type_map = type_map
 
     def dump(self, value, file):

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -98,26 +98,27 @@ Notes
 # License: BSD Style.
 
 # Standard library imports.
+import base64
 import sys
 import types
-import cPickle
+import pickle
 import gzip
-from cStringIO import StringIO
+from io import BytesIO, StringIO
 
 import numpy
 
 # Local imports.
-import version_registry
-from file_path import FilePath
+from . import version_registry
+from .file_path import FilePath
 
-
+PY_VER = sys.version_info[0]
 NumpyArrayType = type(numpy.array([]))
 
 
 def gzip_string(data):
     """Given a string (`data`) this gzips the string and returns it.
     """
-    s = StringIO()
+    s = BytesIO()
     writer = gzip.GzipFile(mode='wb', fileobj=s)
     writer.write(data)
     writer.close()
@@ -129,7 +130,10 @@ def gunzip_string(data):
     """Given a gzipped string (`data`) this unzips the string and
     returns it.
     """
-    s = StringIO(data)
+    if bytes is not str and type(data) is bytes:
+        s = BytesIO(data)
+    else:
+        s = StringIO(data)
     writer = gzip.GzipFile(mode='rb', fileobj=s)
     data = writer.read()
     writer.close()
@@ -192,12 +196,13 @@ class StateTuple(tuple):
     has_instance attribute specifies if the tuple has an instance
     embedded in it.
     """
-    def __init__(self, seq=None):
+    def __new__(cls, seq=None):
         if seq:
-            tuple.__init__(self, seq)
+            obj = super(StateTuple, cls).__new__(cls, tuple(seq))
         else:
-            tuple.__init__(self)
-        self.has_instance = False
+            obj = super(StateTuple, cls).__new__(cls)
+        obj.has_instance = False
+        return obj
 
 
 ######################################################################
@@ -250,22 +255,21 @@ class StatePickler:
     """
     def __init__(self):
         self._clear()
-        type_map = {types.BooleanType: self._do_basic_type,
-                    types.ComplexType: self._do_basic_type,
-                    types.FloatType: self._do_basic_type,
-                    types.IntType: self._do_basic_type,
-                    types.LongType: self._do_basic_type,
-                    types.NoneType: self._do_basic_type,
-                    types.StringType: self._do_basic_type,
-                    types.UnicodeType: self._do_basic_type,
-                    types.TupleType: self._do_tuple,
-                    types.ListType: self._do_list,
-                    types.InstanceType: self._do_instance,
-                    types.DictType: self._do_dict,
-                    types.DictionaryType: self._do_dict,
+        type_map = {bool: self._do_basic_type,
+                    complex: self._do_basic_type,
+                    float: self._do_basic_type,
+                    int: self._do_basic_type,
+                    type(None): self._do_basic_type,
+                    str: self._do_basic_type,
+                    bytes: self._do_basic_type,
+                    tuple: self._do_tuple,
+                    list: self._do_list,
+                    dict: self._do_dict,
                     NumpyArrayType: self._do_numeric,
                     State: self._do_state,
                     }
+        if PY_VER == 2:
+            type_map[long] = self._do_basic_type
         self.type_map = type_map
 
     def dump(self, value, file):
@@ -278,13 +282,13 @@ class StatePickler:
             self.file_name = file.name
         except AttributeError:
             pass
-        cPickle.dump(self._do(value), file)
+        pickle.dump(self._do(value), file)
 
     def dumps(self, value):
         """Pickles the state of the object (`value`) and returns a
         string.
         """
-        return cPickle.dumps(self._do(value))
+        return pickle.dumps(self._do(value))
 
     def dump_state(self, value):
         """Returns a dictionary or a basic type representing the
@@ -440,7 +444,10 @@ class StatePickler:
 
     def _do_numeric(self, value):
         idx = self._register(value)
-        data = gzip_string(numpy.ndarray.dumps(value)).encode('base64')
+        if PY_VER > 2:
+            data = base64.encodebytes(gzip_string(numpy.ndarray.dumps(value)))
+        else:
+            data = base64.encodestring(gzip_string(numpy.ndarray.dumps(value)))
         return dict(type='numeric', id=idx, data=data)
 
 
@@ -504,7 +511,7 @@ class StateUnpickler:
             self.file_name = file.name
         except AttributeError:
             pass
-        data = cPickle.load(file)
+        data = pickle.load(file)
         result = self._process(data)
         return result
 
@@ -512,7 +519,7 @@ class StateUnpickler:
         """Returns the state of an object loaded from the pickled data
         in the given string.
         """
-        data = cPickle.loads(string)
+        data = pickle.loads(string)
         result = self._process(data)
         return result
 
@@ -560,8 +567,9 @@ class StateUnpickler:
         for path in self._instances:
             pth = path
             while pth:
-                exec('val = result%s'%pth)
-                self._set_has_instance(val, True)
+                ns = {'result': result}
+                exec('val = result%s'%pth, ns, ns)
+                self._set_has_instance(ns['val'], True)
                 end = pth.rfind('[')
                 pth = pth[:end]
             # Now make sure that the first element also has_instance.
@@ -569,7 +577,7 @@ class StateUnpickler:
         return result
 
     def _do(self, data, path=''):
-        if type(data) == dict:
+        if type(data) is dict:
             return self.type_map[data['type']](data, path)
         else:
             return data
@@ -634,8 +642,15 @@ class StateUnpickler:
         return result
 
     def _do_numeric(self, value, path):
-        junk = gunzip_string(value['data'].decode('base64'))
-        result = numpy.loads(junk)
+        if PY_VER > 2:
+            data = value['data']
+            if isinstance(data, str):
+                data = value['data'].encode('utf-8')
+            junk = gunzip_string(base64.decodebytes(data))
+            result = numpy.loads(junk, encoding='bytes')
+        else:
+            junk = gunzip_string(value['data'].decode('base64'))
+            result = numpy.loads(junk)
         self._numeric[value['id']] = (path, result)
         self._obj_cache[value['id']] = result
         return result
@@ -702,8 +717,9 @@ class StateSetter:
         """
         if (not isinstance(state, State)) and \
                state.__metadata__['type'] != 'instance':
-            raise StateSetterError, \
-                  'Can only set the attributes of an instance.'
+            raise StateSetterError(
+                'Can only set the attributes of an instance.'
+            )
 
         # Upgrade the state to the latest using the registry.
         self._update_and_check_state(obj, state)
@@ -712,7 +728,7 @@ class StateSetter:
 
         # This wierdness is needed since the state's own `keys` might
         # be set to something else.
-        state_keys = dict.keys(state)
+        state_keys = list(dict.keys(state))
         state_keys.remove('__metadata__')
 
         if first is None:
@@ -775,8 +791,9 @@ class StateSetter:
         """
         result = value
         if self._has_instance(value):
-            raise StateSetterError, \
-                  'Value has an instance: %s'%value
+            raise StateSetterError(
+                'Value has an instance: %s'%value
+            )
         if isinstance(value, (StateList, StateTuple)):
             result = [self._get_pure(x) for x in value]
             if isinstance(value, StateTuple):
@@ -800,20 +817,23 @@ class StateSetter:
         metadata = state.__metadata__
         cls = obj.__class__
         if (metadata['class_name'] != cls.__name__):
-            raise StateSetterError, \
-                  'Instance (%s) and state (%s) do not have the same class'\
-                  ' name!'%(cls.__name__, metadata['class_name'])
+            raise StateSetterError(
+                'Instance (%s) and state (%s) do not have the same class'\
+                ' name!'%(cls.__name__, metadata['class_name'])
+            )
         if (metadata['module'] != cls.__module__):
-            raise StateSetterError, \
-                  'Instance (%s) and state (%s) do not have the same module'\
-                  ' name!'%(cls.__module__, metadata['module'])
+            raise StateSetterError(
+                'Instance (%s) and state (%s) do not have the same module'\
+                ' name!'%(cls.__module__, metadata['module'])
+            )
 
     def _do(self, obj, key, value):
         try:
             attr = getattr(obj, key)
         except AttributeError:
-            raise StateSetterError, \
-                  'Object %s does not have an attribute called: %s'%(obj, key)
+            raise StateSetterError(
+                'Object %s does not have an attribute called: %s'%(obj, key)
+            )
 
         if isinstance(value, (State, StateDict, StateList, StateTuple)):
             # Special handlers are needed.
@@ -867,8 +887,9 @@ class StateSetter:
                 else:
                     self._do_object(obj[i], state[i])
         else:
-            raise StateSetterError,\
-                  'Cannot set state of list of incorrect size.'
+            raise StateSetterError(
+                'Cannot set state of list of incorrect size.'
+            )
 
     def _do_dict(self, obj, state):
         for key, value in state.items():
@@ -886,18 +907,18 @@ class StateSetter:
 def _get_file_read(f):
     if hasattr(f, 'read'):
         return f
-    elif isinstance(f, basestring):
+    elif isinstance(f, str):
         return open(f, 'rb')
     else:
-        raise TypeError, 'Given object is neither a file or String'
+        raise TypeError('Given object is neither a file or String')
 
 def _get_file_write(f):
     if hasattr(f, 'write'):
         return f
-    elif isinstance(f, basestring):
+    elif isinstance(f, str):
         return open(f, 'wb')
     else:
-        raise TypeError, 'Given object is neither a file or String'
+        raise TypeError('Given object is neither a file or String')
 
 
 ######################################################################
@@ -969,7 +990,7 @@ def create_instance(state):
     """
     if (not isinstance(state, State)) and \
            ('class_name'  not in state.__metadata__):
-        raise StateSetterError, 'No class information in state'
+        raise StateSetterError('No class information in state')
     metadata = state.__metadata__
     class_name = metadata.get('class_name')
     mod_name = metadata.get('module')
@@ -982,8 +1003,7 @@ def create_instance(state):
 
     initargs = metadata['initargs']
     if initargs.has_instance:
-        raise StateUnpicklerError, \
-              'Cannot unpickle non-trivial initargs'
+        raise StateUnpicklerError('Cannot unpickle non-trivial initargs')
 
     __import__(mod_name, globals(), locals(), class_name)
     mod = sys.modules[mod_name]

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -550,13 +550,23 @@ class StateUnpickler:
         # Setup all the Numeric arrays.  Do this first since
         # references use this.
         for key, (path, val) in self._numeric.items():
-            exec('result%s = val'%path)
+            if isinstance(result, StateTuple):
+                result = list(result)
+                exec('result%s = val'%path)
+                result = StateTuple(result)
+            else:
+                exec('result%s = val'%path)
 
         # Setup the references so they really are references.
         for key, paths in self._refs.items():
             for path in paths:
                 x = self._obj_cache[key]
-                exec('result%s = x'%path)
+                if isinstance(result, StateTuple):
+                    result = list(result)
+                    exec('result%s = x'%path)
+                    result = StateTuple(result)
+                else:
+                    exec('result%s = x'%path)
                 # if the reference is to an instance append its path.
                 if isinstance(x, State):
                     self._instances.append(path)

--- a/apptools/persistence/tests/test_file_path.py
+++ b/apptools/persistence/tests/test_file_path.py
@@ -10,7 +10,7 @@ import unittest
 import os
 import sys
 from os.path import abspath, dirname, basename, join
-import StringIO
+from io import BytesIO
 
 # Enthought library imports.
 from apptools.persistence import state_pickler
@@ -76,7 +76,7 @@ class TestFilePath(unittest.TestCase):
         curdir = basename(cwd)
 
         # Create a dummy file in the parent dir.
-        s = StringIO.StringIO()
+        s = BytesIO()
         # Spoof its location.
         s.name = abspath(join(cwd, os.pardir, 't.mv2'))
         # Dump into it
@@ -92,7 +92,7 @@ class TestFilePath(unittest.TestCase):
 
 
         # Create a dummy file in a subdir.
-        s = StringIO.StringIO()
+        s = BytesIO()
         # Spoof its location.
         s.name = abspath(join(cwd, 'data', 't.mv2'))
         # Dump into it.

--- a/apptools/persistence/tests/test_spickle.py
+++ b/apptools/persistence/tests/test_spickle.py
@@ -10,7 +10,12 @@ import unittest
 import numpy
 from pickle import dumps
 
-from apptools.persistence import spickle
+try:
+    from apptools.persistence import spickle
+except ImportError:
+    import nose
+    raise nose.SkipTest('spickle is not supported with Python3')
+
 from traits.api import HasTraits, Float, Int
 
 class A:

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -219,10 +219,15 @@ class TestDictPickler(unittest.TestCase):
         # tests pass.  Note that the ID's only need be consistent not
         # identical!
         if TVTK_AVAILABLE:
-            for attr in ('inst', '_tvtk'):
-                getattr(state1, attr).__metadata__['id'] = \
-                    getattr(state, attr).__metadata__['id']
+            instances = ('inst', '_tvtk')
+        else:
+            instances = ('inst',)
 
+        for attr in instances:
+            getattr(state1, attr).__metadata__['id'] = \
+                getattr(state, attr).__metadata__['id']
+
+        if TVTK_AVAILABLE:
             self.assertEqual(state1._tvtk, state._tvtk)
 
         state1.tuple[-1].__metadata__['id'] = \

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -223,6 +223,8 @@ class TestDictPickler(unittest.TestCase):
                 getattr(state1, attr).__metadata__['id'] = \
                     getattr(state, attr).__metadata__['id']
 
+            self.assertEqual(state1._tvtk, state._tvtk)
+
         state1.tuple[-1].__metadata__['id'] = \
             state.tuple[-1].__metadata__['id']
         self.assertEqual(state.inst.__metadata__, state1.inst.__metadata__)
@@ -238,7 +240,6 @@ class TestDictPickler(unittest.TestCase):
         self.assertEqual(id(state.ref), id(state.numeric))
         self.assertEqual(id(state1.ref), id(state1.numeric))
 
-        self.assertEqual(state1._tvtk, state._tvtk)
 
     def test_has_instance(self):
         """Test to check has_instance correctness."""

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -83,7 +83,7 @@ class TestVersionRegistry(unittest.TestCase):
         registry = version_registry.registry
         self.assertEqual(registry.handlers.get(('A', __name__)), h)
         del registry.handlers[('A', __name__)]
-        self.assertNotIn(('A', __name__), registry.handlers)
+        self.assertFalse(('A', __name__) in registry.handlers)
 
     def test_update(self):
         """Test if update method calls the handlers in order."""

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -6,6 +6,7 @@
 # License: BSD Style.
 
 # Standard library imports.
+from imp import reload
 import unittest
 
 # Enthought library imports.
@@ -77,7 +78,7 @@ class TestVersionRegistry(unittest.TestCase):
         registry = version_registry.registry
         self.assertEqual(registry.handlers.get(('A', __name__)), h)
         del registry.handlers[('A', __name__)]
-        self.assertEqual(registry.handlers.has_key(('A', __name__)), False)
+        self.assertNotIn(('A', __name__), registry.handlers)
 
     def test_update(self):
         """Test if update method calls the handlers in order."""

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -6,6 +6,7 @@
 # License: BSD Style.
 
 # Standard library imports.
+import sys
 from imp import reload
 import unittest
 
@@ -42,23 +43,27 @@ class Handler:
 class TestVersionRegistry(unittest.TestCase):
     def test_get_version(self):
         """Test the get_version function."""
+        if sys.version_info[0] > 2:
+            extra = [(('object', 'builtins'), -1)]
+        else:
+            extra = []
         c = Classic()
         v = version_registry.get_version(c)
-        res = [(('Classic', __name__), 0)]
+        res = extra + [(('Classic', __name__), 0)]
         self.assertEqual(v, res)
         state = state_pickler.get_state(c)
         self.assertEqual(state.__metadata__['version'], res)
 
         n = New()
         v = version_registry.get_version(n)
-        res = [(('New', __name__), 0)]
+        res = extra + [(('New', __name__), 0)]
         self.assertEqual(v, res)
         state = state_pickler.get_state(n)
         self.assertEqual(state.__metadata__['version'], res)
 
         t = TraitClass()
         v = version_registry.get_version(t)
-        res = [(('CHasTraits', 'traits.ctraits'), -1),
+        res = extra + [(('CHasTraits', 'traits.ctraits'), -1),
                (('HasTraits', 'traits.has_traits'), -1),
                (('TraitClass', __name__), 0)]
         self.assertEqual(v, res)

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -30,7 +30,7 @@ class NewUnpickler(Unpickler):
 
         # We overload the load_build method.
         dispatch = self.dispatch
-        dispatch[BUILD] = NewUnpickler.load_build
+        dispatch[BUILD[0]] = NewUnpickler.load_build
 
         # call the super class' method.
         ret = Unpickler.load(self)
@@ -38,7 +38,7 @@ class NewUnpickler(Unpickler):
         self.objects = []
 
         # Reset the Unpickler's dispatch table.
-        dispatch[BUILD] = Unpickler.load_build
+        dispatch[BUILD[0]] = Unpickler.load_build
         return ret
 
     def initialize(self, max_pass):

--- a/apptools/preferences/api.py
+++ b/apptools/preferences/api.py
@@ -1,7 +1,7 @@
-from i_preferences import IPreferences
+from .i_preferences import IPreferences
 
-from package_globals import get_default_preferences, set_default_preferences
-from preferences import Preferences
-from preference_binding import PreferenceBinding, bind_preference
-from preferences_helper import PreferencesHelper
-from scoped_preferences import ScopedPreferences
+from .package_globals import get_default_preferences, set_default_preferences
+from .preferences import Preferences
+from .preference_binding import PreferenceBinding, bind_preference
+from .preferences_helper import PreferencesHelper
+from .scoped_preferences import ScopedPreferences

--- a/apptools/preferences/preference_binding.py
+++ b/apptools/preferences/preference_binding.py
@@ -6,8 +6,8 @@ from traits.api import Any, HasTraits, Instance, Str, Undefined
 from traits.api import Unicode
 
 # Local imports.
-from i_preferences import IPreferences
-from package_globals import get_default_preferences
+from .i_preferences import IPreferences
+from .package_globals import get_default_preferences
 
 
 class PreferenceBinding(HasTraits):

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -1,5 +1,6 @@
 """ The default implementation of a node in a preferences hierarchy. """
 
+from __future__ import print_function
 
 # Standard library imports.
 import logging, threading
@@ -9,7 +10,7 @@ from traits.api import Any, Callable, Dict, HasTraits, Instance, List
 from traits.api import Property, Str, Undefined, provides
 
 # Local imports.
-from i_preferences import IPreferences
+from .i_preferences import IPreferences
 
 
 # Logging.
@@ -572,9 +573,9 @@ class Preferences(HasTraits):
         """ Dump the preferences hierarchy to stdout. """
 
         if indent == '':
-            print
+            print()
 
-        print indent, 'Node(%s)' % self.name, self._preferences
+        print(indent, 'Node(%s)' % self.name, self._preferences)
         indent += '  '
 
         for child in self._children.values():
@@ -583,7 +584,3 @@ class Preferences(HasTraits):
         return
 
 #### EOF ######################################################################
-
-
-
-

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -6,7 +6,7 @@ import logging, threading
 
 # Enthought library imports.
 from traits.api import Any, Callable, Dict, HasTraits, Instance, List
-from traits.api import Property, Str, Undefined, implements
+from traits.api import Property, Str, Undefined, provides
 
 # Local imports.
 from i_preferences import IPreferences
@@ -16,10 +16,10 @@ from i_preferences import IPreferences
 logger = logging.getLogger(__name__)
 
 
+@provides(IPreferences)
 class Preferences(HasTraits):
     """ The default implementation of a node in a preferences hierarchy. """
 
-    implements(IPreferences)
 
     #### 'IPreferences' interface #############################################
 

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -8,8 +8,8 @@ import logging
 from traits.api import HasTraits, Instance, Str, Unicode
 
 # Local imports.
-from i_preferences import IPreferences
-from package_globals import get_default_preferences
+from .i_preferences import IPreferences
+from .package_globals import get_default_preferences
 
 
 # Logging.

--- a/apptools/preferences/scoped_preferences.py
+++ b/apptools/preferences/scoped_preferences.py
@@ -1,5 +1,6 @@
 """ A preferences node that adds the notion of preferences scopes. """
 
+from __future__ import print_function
 
 # Standard library imports.
 from os.path import join
@@ -9,8 +10,8 @@ from traits.etsconfig.api import ETSConfig
 from traits.api import List, Str, Undefined
 
 # Local imports.
-from i_preferences import IPreferences
-from preferences import Preferences
+from .i_preferences import IPreferences
+from .preferences import Preferences
 
 
 class ScopedPreferences(Preferences):
@@ -450,9 +451,9 @@ class ScopedPreferences(Preferences):
         """ Dump the preferences hierarchy to stdout. """
 
         if indent == '':
-            print
+            print()
 
-        print indent, 'Node(%s)' % self.name, self._preferences
+        print(indent, 'Node(%s)' % self.name, self._preferences)
         indent += '  '
 
         for child in self.scopes:

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -267,7 +267,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names       = List(Str)
 
         # Cannot create a helper with a preferences path.
-        self.failUnlessRaises(SystemError, AcmeUIPreferencesHelper)
+        self.assertRaises(SystemError, AcmeUIPreferencesHelper)
 
         return
 

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -2,6 +2,7 @@
 
 
 # Standard library imports.
+import time
 import unittest
 
 # Major package imports.
@@ -11,20 +12,27 @@ from pkg_resources import resource_filename
 from apptools.preferences.api import Preferences, PreferencesHelper
 from apptools.preferences.api import ScopedPreferences
 from apptools.preferences.api import set_default_preferences
-from traits.api import Any, Bool, HasTraits, Int, Float, List, Str
-from traits.api import Unicode
+from traits.api import Any, Bool, HasTraits, Int, Float, List, Str, Unicode
 
 
-def listener(obj, trait_name, old, new):
-    """ A useful trait change handler for testing! """
+def width_listener(obj, trait_name, old, new):
 
-    listener.obj = obj
-    listener.trait_name = trait_name
-    listener.old = old
-    listener.new = new
+    width_listener.obj = obj
+    width_listener.trait_name = trait_name
+    width_listener.old = old
+    width_listener.new = new
 
     return
 
+
+def bgcolor_listener(obj, trait_name, old, new):
+
+    bgcolor_listener.obj = obj
+    bgcolor_listener.trait_name = trait_name
+    bgcolor_listener.old = old
+    bgcolor_listener.new = new
+
+    return
 
 # This module's package.
 PKG = 'apptools.preferences.tests'
@@ -78,7 +86,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names       = List(Str)
 
         helper = AcmeUIPreferencesHelper()
-        helper.on_trait_change(listener)
+        helper.on_trait_change(bgcolor_listener)
 
         # Make sure the helper was initialized properly.
         self.assertEqual('blue', helper.bgcolor)
@@ -95,10 +103,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', helper.bgcolor)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('blue', listener.old)
-        self.assertEqual('yellow', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('blue', bgcolor_listener.old)
+        self.assertEqual('yellow', bgcolor_listener.new)
 
         # Make sure we can set the preference via the preferences node...
         p.set('acme.ui.bgcolor', 'red')
@@ -106,10 +114,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('red', helper.bgcolor)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('yellow', listener.old)
-        self.assertEqual('red', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('yellow', bgcolor_listener.old)
+        self.assertEqual('red', bgcolor_listener.new)
 
         return
 
@@ -132,7 +140,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names       = List(Str)
 
         helper = AcmeUIPreferencesHelper(preferences_path='acme.ui')
-        helper.on_trait_change(listener)
+        helper.on_trait_change(bgcolor_listener)
 
         # Make sure the helper was initialized properly.
         self.assertEqual('blue', helper.bgcolor)
@@ -149,10 +157,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', helper.bgcolor)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('blue', listener.old)
-        self.assertEqual('yellow', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('blue', bgcolor_listener.old)
+        self.assertEqual('yellow', bgcolor_listener.new)
 
         # Make sure we can set the preference via the preferences node...
         p.set('acme.ui.bgcolor', 'red')
@@ -160,10 +168,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('red', helper.bgcolor)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('yellow', listener.old)
-        self.assertEqual('red', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('yellow', bgcolor_listener.old)
+        self.assertEqual('red', bgcolor_listener.new)
 
         return
 
@@ -280,7 +288,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             background_color = Str
 
         w = Widget()
-        w.on_trait_change(listener)
+        w.on_trait_change(bgcolor_listener)
 
         p = self.preferences
         p.load(self.example)
@@ -322,10 +330,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', w.background_color)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(w, listener.obj)
-        self.assertEqual('background_color', listener.trait_name)
-        self.assertEqual('blue', listener.old)
-        self.assertEqual('yellow', listener.new)
+        self.assertEqual(w, bgcolor_listener.obj)
+        self.assertEqual('background_color', bgcolor_listener.trait_name)
+        self.assertEqual('blue', bgcolor_listener.old)
+        self.assertEqual('yellow', bgcolor_listener.new)
 
         # Make sure we can set the preference via the preferences node...
         p.set('acme.ui.bgcolor', 'red')
@@ -335,10 +343,10 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('red', w.background_color)
 
         # ... and that the correct trait change event was fired.
-        self.assertEqual(w, listener.obj)
-        self.assertEqual('background_color', listener.trait_name)
-        self.assertEqual('yellow', listener.old)
-        self.assertEqual('red', listener.new)
+        self.assertEqual(w, bgcolor_listener.obj)
+        self.assertEqual('background_color', bgcolor_listener.trait_name)
+        self.assertEqual('yellow', bgcolor_listener.old)
+        self.assertEqual('red', bgcolor_listener.new)
 
         return
 
@@ -400,6 +408,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
     def test_preferences_node_changed(self):
         """ preferences node changed """
+        # from IPython.core.debugger import Tracer; Tracer()()
 
         p = self.preferences
         p.load(self.example)
@@ -422,11 +431,13 @@ class PreferencesHelperTestCase(unittest.TestCase):
         helper = AcmeUIPreferencesHelper()
 
         # We only listen to some of the traits so the testing is easier.
-        helper.on_trait_change(listener, ['bgcolor', 'width'])
+        helper.on_trait_change(width_listener, ['width'])
+        helper.on_trait_change(bgcolor_listener, ['bgcolor'])
 
         # Create a new preference node.
         p1 = Preferences()
         p1.load(self.example)
+
         p1.set('acme.ui.bgcolor', 'red')
         p1.set('acme.ui.width', 40)
 
@@ -434,10 +445,15 @@ class PreferencesHelperTestCase(unittest.TestCase):
         helper.preferences = p1
 
         # Test event handling.
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('width', listener.trait_name)
-        self.assertEqual(50, listener.old)
-        self.assertEqual(40, listener.new)
+        self.assertEqual(helper, width_listener.obj)
+        self.assertEqual('width', width_listener.trait_name)
+        self.assertEqual(50, width_listener.old)
+        self.assertEqual(40, width_listener.new)
+
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('blue', bgcolor_listener.old)
+        self.assertEqual('red', bgcolor_listener.new)
 
         # Test re-initialization.
         self.assertEqual(helper.bgcolor, 'red')
@@ -445,18 +461,18 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         # Test event handling.
         p1.set('acme.ui.bgcolor', 'black')
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('red', listener.old)
-        self.assertEqual('black', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('red', bgcolor_listener.old)
+        self.assertEqual('black', bgcolor_listener.new)
 
         # This should not trigger any new changes since we are setting values
         # on the old preferences node.
         p.set('acme.ui.bgcolor', 'white')
-        self.assertEqual(helper, listener.obj)
-        self.assertEqual('bgcolor', listener.trait_name)
-        self.assertEqual('red', listener.old)
-        self.assertEqual('black', listener.new)
+        self.assertEqual(helper, bgcolor_listener.obj)
+        self.assertEqual('bgcolor', bgcolor_listener.trait_name)
+        self.assertEqual('red', bgcolor_listener.old)
+        self.assertEqual('black', bgcolor_listener.new)
 
         return
 

--- a/apptools/preferences/tests/preferences_helper_test_case.py
+++ b/apptools/preferences/tests/preferences_helper_test_case.py
@@ -408,7 +408,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
     def test_preferences_node_changed(self):
         """ preferences node changed """
-        # from IPython.core.debugger import Tracer; Tracer()()
 
         p = self.preferences
         p.load(self.example)

--- a/apptools/preferences/tests/preferences_test_case.py
+++ b/apptools/preferences/tests/preferences_test_case.py
@@ -135,9 +135,9 @@ class PreferencesTestCase(unittest.TestCase):
 
         p = self.preferences
 
-        self.failUnlessRaises(ValueError, p.get, '')
-        self.failUnlessRaises(ValueError, p.remove, '')
-        self.failUnlessRaises(ValueError, p.set, '', 'a value')
+        self.assertRaises(ValueError, p.get, '')
+        self.assertRaises(ValueError, p.remove, '')
+        self.assertRaises(ValueError, p.set, '', 'a value')
 
         return
 

--- a/apptools/preferences/tests/py_config_file.py
+++ b/apptools/preferences/tests/py_config_file.py
@@ -122,7 +122,7 @@ class PyConfigFile(dict):
         """
 
         if isinstance(file_or_filename, basestring):
-            f = file(file_or_filename, mode)
+            f = open(file_or_filename, mode)
 
         else:
             f = file_or_filename

--- a/apptools/preferences/tests/py_config_file_test_case.py
+++ b/apptools/preferences/tests/py_config_file_test_case.py
@@ -63,7 +63,7 @@ class PyConfigFileTestCase(unittest.TestCase):
     def test_load_from_file(self):
         """ load from file """
 
-        config = PyConfigFile(file(self.example))
+        config = PyConfigFile(open(self.example))
 
         self.assertEqual('blue', config['acme.ui']['bgcolor'])
         self.assertEqual(50, config['acme.ui']['width'])
@@ -82,7 +82,7 @@ class PyConfigFileTestCase(unittest.TestCase):
     def test_save(self):
         """ save """
 
-        config = PyConfigFile(file(self.example))
+        config = PyConfigFile(open(self.example))
 
         self.assertEqual('blue', config['acme.ui']['bgcolor'])
         self.assertEqual(50, config['acme.ui']['width'])
@@ -105,7 +105,7 @@ class PyConfigFileTestCase(unittest.TestCase):
 
             # Make sure we can read the file back in and that we get the same
             # values!
-            config = PyConfigFile(file(tmp))
+            config = PyConfigFile(open(tmp))
 
             self.assertEqual('blue', config['acme.ui']['bgcolor'])
             self.assertEqual(50, config['acme.ui']['width'])

--- a/apptools/preferences/tests/scoped_preferences_test_case.py
+++ b/apptools/preferences/tests/scoped_preferences_test_case.py
@@ -448,7 +448,7 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
 
         p = self.preferences
 
-        self.failUnlessRaises(ValueError, p.get, 'bogus/acme.ui.bgcolor')
+        self.assertRaises(ValueError, p.get, 'bogus/acme.ui.bgcolor')
 
         return
 

--- a/apptools/preferences/ui/preferences_manager.py
+++ b/apptools/preferences/ui/preferences_manager.py
@@ -231,7 +231,7 @@ class PreferencesManager(HasTraits):
         # Sort the pages by the length of their category path. This makes it
         # easy for us to create the preference hierarchy as we know that all of
         # a node's ancestors will have already been created.
-        def sort(a, b):
+        def sort_key(a):
             # We have the guard because if the category is the empty string
             # then split will still return a list containing one item (and not
             # the empty list).
@@ -241,15 +241,9 @@ class PreferencesManager(HasTraits):
             else:
                 len_a = len(a.category.split('/'))
 
-            if len(b.category) == 0:
-                len_b = 0
+            return len_a
 
-            else:
-                len_b = len(b.category.split('/'))
-
-            return cmp(len_a, len_b)
-
-        self.pages.sort(sort)
+        self.pages.sort(key=sort_key)
 
         # Create a corresponding preference node hierarchy (the root of the
         # hierachy is NOT displayed in the preference dialog).

--- a/apptools/preferences/ui/preferences_page.py
+++ b/apptools/preferences/ui/preferences_page.py
@@ -3,16 +3,17 @@
 
 # Enthought library imports.
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Any, Dict, Str, implements
+from traits.api import Any, Dict, Str, provides
 
 # Local imports.
 from i_preferences_page import IPreferencesPage
 
 
+@provides(IPreferencesPage)
 class PreferencesPage(PreferencesHelper):
     """ A page in a preferences dialog. """
 
-    implements(IPreferencesPage)
+
 
     #### 'IPreferencesPage' interface #########################################
 

--- a/apptools/scripting/api.py
+++ b/apptools/scripting/api.py
@@ -4,9 +4,8 @@
 # Copyright (c) 2008, Prabhu Ramachandran and Enthought, Inc.
 # License: BSD Style.
 
-from recorder import Recorder, RecorderError
-from recordable import recordable
-from package_globals import get_recorder, set_recorder
-from recorder_with_ui import RecorderWithUI
-from util import start_recording, stop_recording
-
+from .recorder import Recorder, RecorderError
+from .recordable import recordable
+from .package_globals import get_recorder, set_recorder
+from .recorder_with_ui import RecorderWithUI
+from .util import start_recording, stop_recording

--- a/apptools/scripting/recordable.py
+++ b/apptools/scripting/recordable.py
@@ -5,7 +5,7 @@ Decorator to mark functions and methods as recordable.
 # Copyright (c) 2008, Prabhu Ramachandran and Enthought, Inc.
 # License: BSD Style.
 
-from package_globals import get_recorder
+from .package_globals import get_recorder
 
 
 # Guard to ensure that only the outermost recordable call is recorded
@@ -52,4 +52,3 @@ def recordable(func):
     _wrapper.__dict__.update(func.__dict__)
 
     return _wrapper
-

--- a/apptools/scripting/recorder.py
+++ b/apptools/scripting/recorder.py
@@ -10,12 +10,9 @@ TODO:
 # License: BSD Style.
 
 import warnings
-try:
-    import __builtin__
-    PY_VER = 2
-except ImportError:
-    import builtins as __builtin__
-    PY_VER = 3
+import sys
+PY_VER = sys.version_info[0]
+import __builtin__
 
 from traits.api import (HasTraits, List, Str, Dict, Bool,
         Unicode, Property, Int, Instance)
@@ -376,7 +373,10 @@ class Recorder(HasTraits):
         """Save the recorded lines to the given file.  It does not close
         the file.
         """
-        file.write(self.get_code())
+        if PY_VER == 3:
+            file.write(self.get_code())
+        else:
+            file.write(unicode(self.get_code(), encoding='utf-8'))
         file.flush()
 
     def record_function(self, func, args, kw):
@@ -691,8 +691,8 @@ class Recorder(HasTraits):
         """Return a string given a returned object from a function.
         """
         result = ''
-        long = long if PY_VER == 2 else int
-        ignore = (float, complex, bool, int, long, str)
+        long_type = long if PY_VER == 2 else int
+        ignore = (float, complex, bool, int, long_type, str)
         if object is not None and type(object) not in ignore:
             # If object is not know, register it.
             registry = self._registry

--- a/apptools/scripting/recorder.py
+++ b/apptools/scripting/recorder.py
@@ -6,12 +6,16 @@ TODO:
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) 2008-2015, Enthought, Inc.
 # License: BSD Style.
 
 import warnings
-import types
-import __builtin__
+try:
+    import __builtin__
+    PY_VER = 2
+except ImportError:
+    import builtins as __builtin__
+    PY_VER = 3
 
 from traits.api import (HasTraits, List, Str, Dict, Bool,
         Unicode, Property, Int, Instance)
@@ -291,7 +295,7 @@ class Recorder(HasTraits):
         if hasattr(object, 'recorder'):
             try:
                 object.recorder = self
-            except Exception, e:
+            except Exception as e:
                 msg = "Cannot set 'recorder' trait of object %r: "\
                       "%s"%(object, e)
                 warnings.warn(msg, warnings.RuntimeWarning)
@@ -336,7 +340,7 @@ class Recorder(HasTraits):
         if hasattr(object, 'recorder'):
             try:
                 object.recorder = None
-            except Exception, e:
+            except Exception as e:
                 msg = "Cannot unset 'recorder' trait of object %r:"\
                       "%s"%(object, e)
                 warnings.warn(msg, warnings.RuntimeWarning)
@@ -687,8 +691,8 @@ class Recorder(HasTraits):
         """Return a string given a returned object from a function.
         """
         result = ''
-        ignore = (types.FloatType, types.ComplexType, types.BooleanType,
-                  types.IntType, types.LongType) + types.StringTypes
+        long = long if PY_VER == 2 else int
+        ignore = (float, complex, bool, int, long, str)
         if object is not None and type(object) not in ignore:
             # If object is not know, register it.
             registry = self._registry

--- a/apptools/scripting/recorder_with_ui.py
+++ b/apptools/scripting/recorder_with_ui.py
@@ -9,7 +9,7 @@ from traits.api import Code, Button, Int, on_trait_change, Any
 from traitsui.api import (View, Item, Group, HGroup, CodeEditor,
                                      spring, Handler)
 
-from recorder import Recorder
+from .recorder import Recorder
 
 ######################################################################
 # `CloseHandler` class.
@@ -88,5 +88,3 @@ class RecorderWithUI(Recorder):
 
     def _save_script_fired(self):
         self.ui_save()
-
-

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -2,7 +2,7 @@
 Unit tests for the script recorder.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) 2008-2015, Enthought, Inc.
 # License: BSD Style.
 
 import unittest
@@ -10,8 +10,9 @@ import unittest
 from traits.api import (HasTraits, Float, Instance,
         Str, List, Bool, HasStrictTraits, Tuple, Range, TraitPrefixMap,
         Trait)
-from apptools.scripting.api import (Recorder, recordable,
-    set_recorder)
+from apptools.scripting.recorder import Recorder
+from apptools.scripting.recordable import recordable
+from apptools.scripting.package_globals import set_recorder
 
 
 ######################################################################

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -445,8 +445,8 @@ class TestRecorder(unittest.TestCase):
         tape.recording = False
         tape.unregister(p)
 
-        import StringIO
-        f = StringIO.StringIO()
+        import io
+        f = io.StringIO()
         tape.save(f)
         # Test if the file is OK.
         expect = ["child = parent.children[0]\n",

--- a/apptools/scripting/util.py
+++ b/apptools/scripting/util.py
@@ -4,9 +4,9 @@
 # Copyright (c) 2008,  Prabhu Ramachandran
 # License: BSD Style.
 
-from recorder import Recorder
-from recorder_with_ui import RecorderWithUI
-from package_globals import get_recorder, set_recorder
+from .recorder import Recorder
+from .recorder_with_ui import RecorderWithUI
+from .package_globals import get_recorder, set_recorder
 
 
 ################################################################################
@@ -48,4 +48,3 @@ def stop_recording(object, save=True):
     # Save the script.
     if save:
         recorder.ui_save()
-

--- a/apptools/selection/tests/test_selection_service.py
+++ b/apptools/selection/tests/test_selection_service.py
@@ -237,7 +237,7 @@ class TestSelectionService(unittest.TestCase):
 
         # We can't assume that the order of the items in the selection we set
         # remains stable.
-        self.assertItemsEqual(selection.items, new_selection)
+        self.assertEqual(selection.items, new_selection)
         self.assertEqual(selection.indices, selection.items)
 
     def test_selection_id_not_registered(self):
@@ -262,7 +262,7 @@ class TestSelectionService(unittest.TestCase):
 
         selection = service.get_selection(provider_id)
         self.assertFalse(selection.is_empty())
-        self.assertItemsEqual(selection.items, [0, 1])
+        self.assertEqual(selection.items, [0, 1])
 
         new_selection = [0, 11, 1]
         with self.assertRaises(ValueError):

--- a/apptools/sweet_pickle/__init__.py
+++ b/apptools/sweet_pickle/__init__.py
@@ -114,11 +114,8 @@ def load(file, max_pass=-1):
 
 # Use our custom unpickler to load from strings
 def loads(str, max_pass=-1):
-    try:
-        from cStringIO import StringIO
-    except ImportError:
-        from StringIO import StringIO
-    file = StringIO(str)
+    from io import BytesIO
+    file = BytesIO(str)
 
     return Unpickler(file).load(max_pass)
 

--- a/apptools/sweet_pickle/tests/class_mapping_test_case.py
+++ b/apptools/sweet_pickle/tests/class_mapping_test_case.py
@@ -67,12 +67,9 @@ class ClassMappingTestCase(unittest.TestCase):
             loops of class mappings.
         """
         # Add mappings to the registry
-        self.registry.add_mapping_to_class(Foo.__module__, Foo.__name__,
-            Bar)
-        self.registry.add_mapping_to_class(Bar.__module__, Bar.__name__,
-            Baz)
-        self.registry.add_mapping_to_class(Baz.__module__, Baz.__name__,
-            Foo)
+        self.registry.add_mapping_to_class(Foo.__module__, Foo.__name__, Bar)
+        self.registry.add_mapping_to_class(Bar.__module__, Bar.__name__, Baz)
+        self.registry.add_mapping_to_class(Baz.__module__, Baz.__name__, Foo)
 
         # Validate that an exception is raised when trying to unpickle an
         # instance anywhere within the circular definition.
@@ -86,10 +83,8 @@ class ClassMappingTestCase(unittest.TestCase):
     def test_unpickled_class_mapping(self):
 
         # Add the mappings to the registry
-        self.registry.add_mapping_to_class(Foo.__module__, Foo.__name__,
-            Bar)
-        self.registry.add_mapping_to_class(Bar.__module__, Bar.__name__,
-            Baz)
+        self.registry.add_mapping_to_class(Foo.__module__, Foo.__name__, Bar)
+        self.registry.add_mapping_to_class(Bar.__module__, Bar.__name__, Baz)
 
         # Validate that unpickling the first class gives us an instance of
         # the third class.

--- a/apptools/sweet_pickle/tests/two_stage_unpickler_test_case.py
+++ b/apptools/sweet_pickle/tests/two_stage_unpickler_test_case.py
@@ -111,8 +111,7 @@ class StringFinder(object):
     def find(self):
         pattern = self.pattern
         string = self.source.data
-        self.data = [(x.start(), x.end()) \
-                     for x in re.finditer(pattern, string)]
+        self.data = [(x.start(), x.end()) for x in re.finditer(pattern, string)]
 
 
 class XMLFileReader(object):
@@ -177,5 +176,3 @@ if __name__ == '__main__':
     test_generic()
     test_toy_app()
     print 'ALL TESTS SUCCESFULL\n'
-
-

--- a/apptools/template/impl/any_context_data_name_item.py
+++ b/apptools/template/impl/any_context_data_name_item.py
@@ -24,7 +24,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import HasPrivateTraits, Instance, Property, implements, on_trait_change
+    import HasPrivateTraits, Instance, Property, provides, on_trait_change
 
 from apptools.template.itemplate_data_context \
     import ITemplateDataContext

--- a/apptools/template/impl/any_data_name_item.py
+++ b/apptools/template/impl/any_data_name_item.py
@@ -22,7 +22,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import HasPrivateTraits, Instance, Property, implements
+    import HasPrivateTraits, Instance, Property, provides
 
 from apptools.template.template_traits \
     import TBool

--- a/apptools/template/impl/template_data_context.py
+++ b/apptools/template/impl/template_data_context.py
@@ -24,7 +24,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api\
-    import HasPrivateTraits, Dict, Str, Any, Property, implements, \
+    import HasPrivateTraits, Dict, Str, Any, Property, provides, \
            cached_property
 
 from apptools.template.itemplate_data_context \

--- a/apptools/template/impl/template_data_source.py
+++ b/apptools/template/impl/template_data_source.py
@@ -20,7 +20,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import implements
+    import provides
 
 from apptools.template.template_data_name \
     import TemplateDataName

--- a/apptools/template/mutable_template.py
+++ b/apptools/template/mutable_template.py
@@ -18,7 +18,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import Event, implements
+    import Event, provides
 
 from template_impl \
     import Template

--- a/apptools/template/template_choice.py
+++ b/apptools/template/template_choice.py
@@ -16,7 +16,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import HasPrivateTraits, Str, implements
+    import HasPrivateTraits, Str, provides
 
 from itemplate_choice \
     import ITemplateChoice

--- a/apptools/template/template_impl.py
+++ b/apptools/template/template_impl.py
@@ -20,7 +20,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import HasPrivateTraits, Undefined, implements
+    import HasPrivateTraits, Undefined, provides
 
 from itemplate \
     import ITemplate

--- a/apptools/type_manager/util.py
+++ b/apptools/type_manager/util.py
@@ -35,17 +35,10 @@ def sort_by_class_tree(objs):
     # This returns them ordered from least specific to most specific.
     classes = get_classes(hierarchy)
 
-    # Now we can actually do the sort!
-    def by_class_tree(x, y):
-        ix = classes.index(type(x))
-        iy = classes.index(type(y))
-
-        # Note the reverse comparison (i.e., compare y with x). This is
-        # because we want to return the classes ordered from the MOST
-        # specfic to the least specific.
-        return cmp(iy, ix)
-
-    objs.sort(by_class_tree)
+    # Note the reverse comparison (i.e., compare y with x). This is
+    # because we want to return the classes ordered from the MOST
+    # specfic to the least specific.
+    objs.sort(key=lambda x: classes.index(type(x)), reverse=True)
 
     return
 

--- a/examples/permissions/server/enthought/permissions/external/policy_storage.py
+++ b/examples/permissions/server/enthought/permissions/external/policy_storage.py
@@ -16,16 +16,17 @@
 # Enthought library imports.
 from apptools.permissions.default.api import IPolicyStorage, \
         PolicyStorageError
-from traits.api import HasTraits, implements
+from traits.api import HasTraits, provides
 
 # Local imports.
 from proxy_server import ProxyServer
 
 
+@provides(IPolicyStorage)
 class PolicyStorage(HasTraits):
     """This implements a policy database accessed via XML RPC."""
 
-    implements(IPolicyStorage)
+
 
     ###########################################################################
     # 'IPolicyStorage' interface.

--- a/examples/permissions/server/enthought/permissions/external/user_storage.py
+++ b/examples/permissions/server/enthought/permissions/external/user_storage.py
@@ -19,16 +19,17 @@ import socket
 
 # Enthought library imports.
 from apptools.permissions.default.api import IUserStorage, UserStorageError
-from traits.api import HasTraits, implements, List, Str
+from traits.api import HasTraits, provides, List, Str
 
 # Local imports.
 from proxy_server import ProxyServer
 
 
+@provides(IUserStorage)
 class UserStorage(HasTraits):
     """This implements a user database accessed via XML RPC."""
 
-    implements(IUserStorage)
+
 
     #### 'IUserStorage' interface #############################################
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 import re
 import subprocess
-
+import sys
 from setuptools import setup, find_packages
 
 MAJOR = 4
@@ -130,6 +130,7 @@ if __name__ == "__main__":
                                      'logger/plugin/*.ini',
                                      'logger/plugin/view/images/*.png',
                                      'naming/ui/images/*.png',
+                                     'preferences/tests/*.ini'
                                      ]
                         },
           install_requires=__requires__,
@@ -137,4 +138,5 @@ if __name__ == "__main__":
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
+          use_2to3 = sys.version_info[0] > 2
           )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import os
 import re
 import subprocess
-import sys
 from setuptools import setup, find_packages
 
 MAJOR = 4
@@ -138,5 +137,5 @@ if __name__ == "__main__":
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
-          use_2to3 = sys.version_info[0] > 2
+          use_2to3=True
           )

--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -5,3 +5,4 @@ tables
 pandas
 unittest2 ; python_version <= "2.6"
 ordereddict ; python_version <= "2.6"
+git+http://github.com/enthought/pyface.git#egg=pyface ; python_version >= "3.0"


### PR DESCRIPTION
This fixes most of the tests on apptools with Python3.  The io.h5 package has a bunch of issues but the others pass.  These changes are needed for Mayavi.  The changes cherry pick commits from Pradyun's PR here: #18.