### PR TITLE
Fix state_pickler.dump in py2

### DIFF
--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -918,18 +918,14 @@ class StateSetter:
 def _get_file_read(f):
     if hasattr(f, 'read'):
         return f
-    elif isinstance(f, str):
-        return open(f, 'rb')
     else:
-        raise TypeError('Given object is neither a file or String')
+        return open(f, 'rb')
 
 def _get_file_write(f):
     if hasattr(f, 'write'):
         return f
-    elif isinstance(f, str):
-        return open(f, 'wb')
     else:
-        raise TypeError('Given object is neither a file or String')
+        return open(f, 'wb')
 
 
 ######################################################################

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -8,6 +8,8 @@
 import base64
 import unittest
 import math
+import os
+import tempfile
 
 import numpy
 
@@ -449,6 +451,17 @@ class TestDictPickler(unittest.TestCase):
         del B.__getstate__
         s = state_pickler.get_state(b)
         self.assertEqual(s.a, 'dict')
+
+    def test_dump_to_file_str(self):
+        """Test if dump can take a str as file"""
+        obj = A()
+
+        filepath = os.path.join(tempfile.gettempdir(), "tmp.file")
+
+        try:
+            state_pickler.dump(obj, filepath)
+        finally:
+            os.remove(filepath)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Python2 environment, `state_pickler.dump(obj, u'file.path')` would raise an Error, but it is not necessary to do further type checking as `open` already handles that for us.

@prabhuramachandran can you take a look please?  This problem arises when trying Save/Load visualization in Mayavi2 in Python2.7 environment.
