### PR TITLE
Handle numpy pure scalar types

### DIFF
--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -480,6 +480,7 @@ class StatePickler:
 
     def _do_numpy_generic_type(self, value):
         idx = self._register(value)
+        self._misc_cache.append(value)
         data = base64_encode(pickle.dumps(value))
         return dict(type='numpy', id=idx, data=data)
 

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -481,7 +481,7 @@ class StatePickler:
     def _do_numpy_generic_type(self, value):
         idx = self._register(value)
         self._misc_cache.append(value)
-        data = base64_encode(pickle.dumps(value))
+        data = base64_encode(value.dumps())
         return dict(type='numpy', id=idx, data=data)
 
 
@@ -700,7 +700,7 @@ class StateUnpickler:
         return result
 
     def _do_numpy_generic_type(self, value, path):
-        result = pickle.loads(base64_decode(value["data"]))
+        result = numpy.loads(base64_decode(value["data"]))
         self._obj_cache[value['id']] = result
         return result
 

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -142,7 +142,7 @@ def gunzip_string(data):
 
 def base64_encode(data):
     if PY_VER > 2:
-        base64.encodebytes(data)
+        return base64.encodebytes(data)
     else:
         return base64.encodestring(data)
 

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -490,6 +490,11 @@ class TestStatePickler(unittest.TestCase):
              'id': 0,
              'type': 'list'})
 
+    def test_on_numpy_scalars(self):
+        state = self.pickler.dumps(numpy.int32(78))
+        loaded_state = state_pickler.StateUnpickler().loads_state(state)
+        self.assertEqual(loaded_state, 78)
+        self.assertEqual(loaded_state.dtype, numpy.int32)
 
 
 if __name__ == "__main__":

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -44,6 +44,7 @@ class TestClassic:
         self.i = 7
         self.l = 1234567890123456789
         self.f = math.pi
+        self.fnumpy = numpy.float64(3.0)
         self.c = complex(1.01234, 2.3)
         self.n = None
         self.s = 'String'
@@ -65,6 +66,7 @@ class TestTraits(HasTraits):
     i = Int(7)
     l = Long(12345678901234567890)
     f = Float(math.pi)
+    fnumpy = Float(numpy.float64(3.0))
     c = Complex(complex(1.01234, 2.3))
     n = Any
     s = Str('String')
@@ -168,6 +170,9 @@ class TestDictPickler(unittest.TestCase):
         self.assertEqual(state.i, obj.i)
         self.assertEqual(state.l, obj.l)
         self.assertEqual(state.f, obj.f)
+        self.assertEqual(state.fnumpy, obj.fnumpy)
+        self.assertIsInstance(obj.fnumpy, numpy.generic)
+        self.assertEqual(type(state.fnumpy), type(obj.fnumpy))
         self.assertEqual(state.c, obj.c)
         self.assertEqual(state.n, obj.n)
         self.assertEqual(state.s, obj.s)

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -469,5 +469,28 @@ class TestDictPickler(unittest.TestCase):
             os.remove(filepath)
 
 
+class TestStatePickler(unittest.TestCase):
+
+    def setUp(self):
+        self.pickler = state_pickler.StatePickler()
+
+    def tearDown(self):
+        self.pickler = None
+
+    def test_on_base_types(self):
+        state = self.pickler.dump_state(1)
+        self.assertEqual(state, 1)
+
+    def test_on_lists(self):
+        l = [1,2.0, None, [1,2,3]]
+        state = self.pickler.dump_state(l)
+        self.assertEqual(
+            state,
+            {'data': [1, 2.0, None, {'data': [1, 2, 3], 'type': 'list', 'id': 1}],
+             'id': 0,
+             'type': 'list'})
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apptools/preferences/tests/example.ini
+++ b/apptools/preferences/tests/example.ini
@@ -1,10 +1,10 @@
 [acme.ui]
-bgcolor = blue
-width = 50
 ratio = 1.0
-visible = True
-description = 'acme ui'
+description = acme ui
+width = 50
 offsets = "[1, 2, 3, 4]"
+bgcolor = blue
+visible = True
 names = "['joe', 'fred', 'jane']"
 
 [acme.ui.splash_screen]


### PR DESCRIPTION
spawned from https://github.com/enthought/mayavi/issues/61
The state pickler/unpickler could not handle numpy scalar types,
which were forced to None. This meant that trait classes having
Float() trait hosting a numpy.float64 could not be pickled
(to be precise they were pickled, with the content being None, silently).
