### PR TITLE
Dropping python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 python:
   - 2.7
-  - 2.6
   - 3.4
 addons:
   apt:

--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -3,6 +3,4 @@ configobj
 coverage
 tables
 pandas
-unittest2 ; python_version <= "2.6"
-ordereddict ; python_version <= "2.6"
 git+http://github.com/enthought/pyface.git#egg=pyface ; python_version >= "3.0"


### PR DESCRIPTION
As agreed with @dpinte in pull request #62, we are dropping 2.6 support for apptools.
This will not bring master back to green, but it's a factor.