### PR TITLE
Fix mismatched PyFace and Traits UI requirements.

### DIFF
--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -3,4 +3,4 @@ configobj
 coverage
 tables
 pandas
-git+http://github.com/enthought/pyface.git#egg=pyface ; python_version >= "3.0"
+git+http://github.com/enthought/pyface.git#egg=pyface


### PR DESCRIPTION
We're using Traits UI master, but only using PyFace master for Python 3. The PyFace and Traits UI requirements need to be matched on both Python 2 and Python 3.