### PR TITLE
[WIP] Remove use of 2to3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ notifications:
   email: false
 python:
   - 2.7
-  - 3.4
+  - 3.5
+  - 3.6
 addons:
   apt:
     packages:

--- a/apptools/io/__init__.py
+++ b/apptools/io/__init__.py
@@ -14,4 +14,4 @@
 """ Provides an abstraction for files and folders in a file system.
     Part of the AppTools project of the Enthought Tool Suite.
 """
-from api import *
+from .api import *

--- a/apptools/io/api.py
+++ b/apptools/io/api.py
@@ -11,4 +11,4 @@
 # Author: Enthought, Inc.
 # Description: <Enthought IO package component>
 #------------------------------------------------------------------------------
-from file import File
+from .file import File

--- a/apptools/io/h5/dict_node.py
+++ b/apptools/io/h5/dict_node.py
@@ -69,7 +69,7 @@ class H5DictNode(object):
         return key in self.data
 
     def keys(self):
-        return self.data.keys()
+        return list(self.data.keys())
 
     #--------------------------------------------------------------------------
     #  Public interface
@@ -213,8 +213,12 @@ class H5DictNode(object):
 
         # Remove stored arrays which are no longer in the data dictionary.
         pyt_children = group._v_children
+        keys_to_remove = []
         for key in pyt_children.keys():
             if key not in data:
-                pyt_file.remove_node(group, key)
+                keys_to_remove.append(key)
+
+        for key in keys_to_remove:
+            pyt_file.remove_node(group, key)
 
         return out_data

--- a/apptools/io/h5/file.py
+++ b/apptools/io/h5/file.py
@@ -427,7 +427,7 @@ class H5Group(Mapping):
 
     @property
     def subgroup_names(self):
-        return self._h5_group._v_groups.keys()
+        return list(self._h5_group._v_groups.keys())
 
     def iter_groups(self):
         """ Iterate over `H5Group` nodes that are children of this group. """

--- a/apptools/io/h5/table_node.py
+++ b/apptools/io/h5/table_node.py
@@ -1,3 +1,5 @@
+import six
+
 import numpy as np
 from pandas import DataFrame
 from tables.table import Table as PyTablesTable
@@ -78,7 +80,7 @@ class H5TableNode(object):
         data : dict
             A dictionary of column name -> values items
         """
-        rows = zip(*[data[name] for name in self.keys()])
+        rows = list(zip(*[data[name] for name in self.keys()]))
         self._h5_table.append(rows)
 
     def __getitem__(self, col_or_cols):
@@ -95,7 +97,7 @@ class H5TableNode(object):
             An array of column data with the column order matching that of
             `col_or_cols`.
         """
-        if isinstance(col_or_cols, basestring):
+        if isinstance(col_or_cols, six.string_types[0]):
             return self._h5_table.col(col_or_cols)
 
         column_data = [self._h5_table.col(name) for name in col_or_cols]

--- a/apptools/io/h5/tests/test_dict_node.py
+++ b/apptools/io/h5/tests/test_dict_node.py
@@ -1,3 +1,5 @@
+import six
+
 import numpy as np
 from numpy.testing import raises, assert_allclose
 
@@ -170,14 +172,15 @@ def test_basic_dtypes():
         h5dict = H5DictNode.add_to_h5file(h5, NODE, data)
         assert isinstance(h5dict['a_int'], int)
         assert isinstance(h5dict['a_float'], float)
-        assert isinstance(h5dict['a_str'], basestring)
+        assert isinstance(h5dict['a_str'], six.string_types[0])
 
 
 def test_mixed_type_list():
     with temp_h5_file() as h5:
         data = dict(a=[1, 1.0, 'abc'])
         h5dict = H5DictNode.add_to_h5file(h5, NODE, data)
-        for value, dtype in zip(h5dict['a'], (int, float, basestring)):
+        for value, dtype in zip(
+                h5dict['a'], (int, float, six.string_types[0])):
             assert isinstance(value, dtype)
 
 

--- a/apptools/io/h5/tests/test_file.py
+++ b/apptools/io/h5/tests/test_file.py
@@ -514,7 +514,7 @@ def test_attribute_iteration_methods():
         assert all(isinstance(x, tuple) for x in items)
 
         # unfold the pairs
-        keys, vals = map(list, zip(*items))
+        keys, vals = map(list, list(zip(*items)))
 
         assert keys == attrs.keys()
         assert vals == attrs.values()

--- a/setup.py
+++ b/setup.py
@@ -137,5 +137,4 @@ if __name__ == "__main__":
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
-          use_2to3=True
           )


### PR DESCRIPTION
`apptools` currently uses `2to3` to support python >3. 

- Note that this PR drops testing for 3.4