### PR TITLE
FIX: Use trait_set instead of set

### DIFF
--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -163,7 +163,7 @@ class PreferencesHelper(HasTraits):
                 value = self._get_value(trait_name, preferences.get(key))
                 traits_to_set[trait_name] = value
 
-        self.set(trait_change_notify=notify, **traits_to_set)
+        self.trait_set(trait_change_notify=notify, **traits_to_set)
 
         # Listen for changes to the node's preferences.
         preferences.add_preferences_listener(


### PR DESCRIPTION
Fixes warnings of the form:
```
apptools/preferences/preferences_helper.py:166: DeprecationWarning: use "HasTraits.trait_set" instead
    self.set(trait_change_notify=notify, **traits_to_set)
```
Let me know if this needs to be a `try: self.trait_set(...); except AttributeError: self.set(...)` for backward compat and I can change it.