### PR TITLE
Implementing execfile so docs can be built with python3 sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,16 @@
 
 import sys, os
 
+def execfile(filepath, globals=None, locals=None):
+    if globals is None:
+        globals = {}
+    globals.update({
+        "__file__": filepath,
+        "__name__": "__main__",
+    })
+    with open(filepath, 'rb') as file:
+        exec(compile(file.read(), filepath, 'exec'), globals, locals)
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.


### PR DESCRIPTION
Documentation can built with python2 sphinx, but execfile() fails when built with the python3 sphinx.  Adding an implementation of execfile so that it can now be built.