### PR TITLE
Fixing auto-build problems with small containers

### DIFF
--- a/apptools/preferences/tests/preference_binding_test_case.py
+++ b/apptools/preferences/tests/preference_binding_test_case.py
@@ -211,7 +211,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
 
         # Clean up!
         os.remove(tmp)
-        os.removedirs(tmpdir)
+        os.rmdir(tmpdir)
 
         return
 

--- a/apptools/preferences/tests/preferences_test_case.py
+++ b/apptools/preferences/tests/preferences_test_case.py
@@ -40,7 +40,7 @@ class PreferencesTestCase(unittest.TestCase):
         """ Called immediately after each test method has been called. """
 
         # Remove the temporary directory.
-        os.removedirs(self.tmpdir)
+        os.rmdir(self.tmpdir)
 
         return
 

--- a/apptools/preferences/tests/py_config_file_test_case.py
+++ b/apptools/preferences/tests/py_config_file_test_case.py
@@ -122,7 +122,7 @@ class PyConfigFileTestCase(unittest.TestCase):
         finally:
             # Clean up!
             os.remove(tmp)
-            os.removedirs(tmpdir)
+            os.rmdirs(tmpdir)
 
         return
 

--- a/apptools/preferences/tests/scoped_preferences_test_case.py
+++ b/apptools/preferences/tests/scoped_preferences_test_case.py
@@ -43,7 +43,7 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         """ Called immediately after each test method has been called. """
 
         # Remove the temporary directory.
-        os.removedirs(self.tmpdir)
+        os.rmdir(self.tmpdir)
 
         return
 


### PR DESCRIPTION
Self tests will fail if we build this package in an isolated chroot environment. 

That's because os.removedirs() was used.  This deletes parent directories if empty.  In our case, we were building with root permissions (normal for chroot), in an isolated enviornment.  The /tmp directory was empty, so when tests ran os.removedirs(), /tmp was also deleted.  The next test that tried to tempfile.mkdtemp() would fail because it couldn't create a new directory in /tmp because /tmp didn't exist.