### PR TITLE
Treating traitsui as optional

### DIFF
--- a/apptools/__init__.py
+++ b/apptools/__init__.py
@@ -7,6 +7,5 @@ except ImportError:
     __version__ = 'not-built'
 
 __requires__ = [
-    'traitsui',
     'configobj',
 ]

--- a/apptools/naming/trait_defs/naming_traits.py
+++ b/apptools/naming/trait_defs/naming_traits.py
@@ -22,8 +22,11 @@ from traits.api \
 from traits.trait_base \
     import class_of, get_module_name
 
-from traitsui.api \
-    import DropEditor
+try:
+    from traitsui.api \
+        import DropEditor
+except ImportError:
+    pass
 
 from apptools.naming.api \
     import Binding
@@ -101,11 +104,15 @@ class NamingTraitHandler ( TraitHandler ):
 
     def get_editor ( self, trait ):
         if self.editor is None:
-            from traitsui.api import DropEditor
+            try:
+                from traitsui.api import DropEditor
 
-            self.editor = DropEditor( klass    = self.aClass,
-                                      binding  = True,
-                                      readonly = False )
+                self.editor = DropEditor( klass    = self.aClass,
+                                          binding  = True,
+                                          readonly = False )
+            except ImportError:
+                pass
+
         return self.editor
 
     def post_setattr ( self, object, name, value ):


### PR DESCRIPTION
If users don't have traitsui, then GUI-specific functions now do nothing instead of crashing the application.  This really helps for running unit tests on build machines without any X-server which have problems when running traitsui functions.

Note that there probably some other places where traitsui could be removed, but this at least gets the CI tests working.

Also helps with issue #70.