### PR TITLE
Fixing some spelling in documentation

### DIFF
--- a/docs/source/appscripting/Introduction.rst
+++ b/docs/source/appscripting/Introduction.rst
@@ -58,12 +58,12 @@ The following are the concepts supported by the framework.
   possible for a recording to be run directly by the Python interpreter and
   independently of the application that made the recording.  Otherwise the
   application must run the script and first create any scriptable objects
-  refered to in the script.
+  referred to in the script.
 
 - Binding
 
   A script runs in a namespace which is, by default, empty.  If the scriptable
-  objects refered to in a script are not created by the script (because their
+  objects referred to in a script are not created by the script (because their
   type's ``__init__()`` method isn't scriptable) then they must be created by
   the application and added to the namespace.  Adding an object to the
   namespace is called binding.

--- a/docs/source/scripting/introduction.rst
+++ b/docs/source/scripting/introduction.rst
@@ -179,7 +179,7 @@ Here are a few advanced use cases.
    user to save the script.
 
  - Sometimes it is not enough to just record trait changes, one may want
-   to pass an arbitrary string or command when recording is occuring.
+   to pass an arbitrary string or command when recording is occurring.
    To allow for this, if one defines a ``recorder`` trait on the object,
    it is set to the current recorder.  One can then use this recorder to
    do whatever one wants.  This is very convenient.


### PR DESCRIPTION
Addressing spelling-error-in-manpage lintian tag.