### PR TITLE
Skipping a unit test when run as root

### DIFF
--- a/apptools/io/tests/file_test_case.py
+++ b/apptools/io/tests/file_test_case.py
@@ -51,7 +51,7 @@ class FileTestCase(unittest.TestCase):
     ###########################################################################
     # Tests.
     ###########################################################################
-
+    @unittest.skipIf(os.getuid() == 0, "Cannot be run as root")
     def test_properties(self):
         """ file properties """
 


### PR DESCRIPTION
When building and testing the package in a chroot enviornment, we have a root user.  However, test_properties fails when run as a root user.

```
os.chmod(f.path, stat.S_IRUSR)
self.assertEqual(f.is_readonly, True)
```

This fails because root will always have permission to write to the file.  That makes sense.  And it also therefore makes sense to skip this test when run as root.