### PR TITLE
Add six, numpy and pandas to requirements

### DIFF
--- a/apptools/__init__.py
+++ b/apptools/__init__.py
@@ -7,6 +7,9 @@ except ImportError:
     __version__ = 'not-built'
 
 __requires__ = [
-    'traitsui',
     'configobj',
+    'numpy',
+    'pandas',
+    'six',
+    'traitsui',
 ]


### PR DESCRIPTION
`six` is now a runtime requirement because we removed the use of `2to3` in the package.
`numpy` and `pandas` have been runtime requirements of a few submodules of `apptools` which were never reported.

fixes #99 