### PR TITLE
Release version 4.5.0 of apptools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Version 4.5.0
 
 Released : 10 October 2019
 
+* Add missing `long_description_content_type` field in setup. (#108)
 * Remove use of `2to3`. (#90)
 * Use etstool for CI tasks. Setup travis macos and appveyor CI. (#92)
 * Temporarily change cwd when running tests. (#104)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ MAJOR = 4
 MINOR = 5
 MICRO = 0
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ if __name__ == "__main__":
               """.splitlines() if len(c.strip()) > 0],
           description='application tools',
           long_description=open('README.rst').read(),
+          long_description_content_type="text/x-rst",
           include_package_data=True,
           package_data={'apptools': ['help/help_plugin/*.ini',
                                      'help/help_plugin/action/images/*.png',


### PR DESCRIPTION
Set `IS_RELEASED` to `True`. Note that the PR is against the `release/4.5.x` branch.
Note that this branch also contains a commit cherry-picked from master, which contains the fixes from PR #108 