### PR TITLE
Add long_description_content_type in setup.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Version 4.5.0
 
 Released : 10 October 2019
 
+* Add missing `long_description_content_type` field in setup. (#108)
 * Remove use of `2to3`. (#90)
 * Use etstool for CI tasks. Setup travis macos and appveyor CI. (#92)
 * Temporarily change cwd when running tests. (#104)

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ if __name__ == "__main__":
               """.splitlines() if len(c.strip()) > 0],
           description='application tools',
           long_description=open('README.rst').read(),
+          long_description_content_type="text/x-rst",
           include_package_data=True,
           package_data={'apptools': ['help/help_plugin/*.ini',
                                      'help/help_plugin/action/images/*.png',


### PR DESCRIPTION
`twine check` was unhappy because of the missing `long_description_content_type` kwarg to `setuptools.setup`. This PR fixes that issue.

Weirdly enough, even after adding this kwarg, `twine check` is still unhappy because of a bug upstream in `twine`.