### PR TITLE
Add missing image license file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE.txt
 include MANIFEST.in
 include TODO.txt
 include image_LICENSE.txt
+include image_LICENSE_Nuvola.txt
 include image_LICENSE_OOo.txt
 graft docs
 prune docs/build


### PR DESCRIPTION
Specifically, the `image_LICENSE_Nuvola.txt` file was missing from the manifest and so it was missing from the sdist.

fixes #109 