### PR TITLE
Replace a use of the deprecated Long trait with Int

### DIFF
--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -14,7 +14,7 @@ import tempfile
 
 import numpy
 
-from traits.api import Bool, Int, Long, Array, Float, Complex, Any, \
+from traits.api import Bool, Int, Array, Float, Complex, Any, \
     Str, Unicode, Instance, Tuple, List, Dict, HasTraits
 
 try:
@@ -64,7 +64,7 @@ class TestClassic:
 class TestTraits(HasTraits):
     b = Bool(False)
     i = Int(7)
-    l = Long(12345678901234567890)
+    l = Int(12345678901234567890)
     f = Float(math.pi)
     c = Complex(complex(1.01234, 2.3))
     n = Any


### PR DESCRIPTION
The `Long` trait is scheduled to be removed in Traits 6.0.0 (though we may have to rethink that: see enthought/traits#643). This PR replaces the sole use of `Long` in this repository with `Int`.