### PR TITLE
Fix SyntaxWarning in file_path.py

### DIFF
--- a/apptools/persistence/file_path.py
+++ b/apptools/persistence/file_path.py
@@ -67,7 +67,7 @@ class FilePath(object):
         ret = (_src.count(os.sep) * ('..' + os.sep)) + _dst
 
         # Make it posix style.
-        if os.sep is not '/':
+        if os.sep != '/':
             ret.replace(os.sep, '/')
 
         # Store it.


### PR DESCRIPTION
Fixes this SyntaxWarning:
/usr/lib/python3/dist-packages/apptools/persistence/file_path.py:70: SyntaxWarni
ng: "is not" with a literal. Did you mean "!="?
  if os.sep is not '/':