### PR TITLE
Work around broken _v_groups.itervalues() in PyTables

### DIFF
--- a/apptools/io/h5/file.py
+++ b/apptools/io/h5/file.py
@@ -431,7 +431,12 @@ class H5Group(Mapping):
 
     def iter_groups(self):
         """ Iterate over `H5Group` nodes that are children of this group. """
-        return (_wrap_node(g) for g in self._h5_group._v_groups.itervalues())
+        groups = self._h5_group._v_groups
+
+        # not using the groups.values() method here, because groups is a
+        # `proxydict` object whose .values() method is non-lazy. Related:
+        # PyTables/PyTables#784.
+        return (_wrap_node(groups[group_name]) for group_name in groups)
 
     @h5_group_wrapper(H5File.create_group)
     def create_group(self, group_subpath, delete_existing=False, **kwargs):


### PR DESCRIPTION
Fixes #115, by avoiding the use of `_v_groups.itervalues()` and thereby avoiding PyTables/PyTables#784.

No regression test, because there was already a test that was failing under Python 3.8.

We don't have Python 3.8 support in `etstool`: to verify the fix, you'll need to do something like:

- Create a new Python 3.8 venv and activate it.
- Do a `pip install nose numpy pandas tables` to get the necessary dependencies to run the test suite.
- Install `apptools` with `pip install -e .` from the root directory of the repository.
- Run the tests with `nosetests .`

That test run should fail before this fix, and succeed after it.