### PR TITLE
Fix uses of the "new" module

### DIFF
--- a/apptools/help/help_plugin/help_plugin.py
+++ b/apptools/help/help_plugin/help_plugin.py
@@ -14,7 +14,6 @@ It assumes that the Workbench plugin is being used.
 
 # Standard library imports.
 import logging
-import new
 
 # Enthought libary imports
 from envisage.api import Plugin, ExtensionPoint
@@ -235,7 +234,7 @@ class HelpPlugin(Plugin):
                 # Append the menu.
                 ns.setdefault('menus', []).append(menu)
 
-        return [new.classobj('SPLHelpActionSet', (ActionSet,), ns)]
+        return [type('SPLHelpActionSet', (ActionSet,), ns)]
 
     preferences = List(contributes_to=PREFERENCES)
     def _preferences_default(self):
@@ -251,7 +250,7 @@ class HelpPlugin(Plugin):
         if len(self.help_docs) > 0:
             pages.append(DocumentsPreferencesPage)
             pages.extend(
-                [ new.classobj(doc.preferences_path + 'PreferencesPage',
+                [ type(doc.preferences_path + 'PreferencesPage',
                               (HelpDocPreferencesPage,),
                               {'preferences_path': doc.preferences_path},
                              ) for doc in self.help_docs
@@ -259,7 +258,7 @@ class HelpPlugin(Plugin):
         if len(self.help_demos) > 0:
             pages.append(DemosPreferencesPage)
             pages.extend(
-                [ new.classobj(demo.preferences_path + 'PreferencesPage',
+                [ type(demo.preferences_path + 'PreferencesPage',
                               (HelpDemoPreferencesPage,),
                               {'preferences_path': demo.preferences_path},
                              ) for demo in self.help_demos
@@ -267,7 +266,7 @@ class HelpPlugin(Plugin):
         if len(self.help_examples) > 0:
             pages.append(ExamplesPreferencesPage)
             pages.extend(
-                [ new.classobj(example.preferences_path + 'PreferencesPage',
+                [ type(example.preferences_path + 'PreferencesPage',
                               (HelpExamplePreferencesPage,),
                               {'preferences_path': example.preferences_path},
                              ) for example in self.help_examples

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -1,14 +1,28 @@
 # Standard library imports
 from pickle import *
-import sys, new
+import sys
 import logging
-from types import GeneratorType
+from types import GeneratorType, MethodType
 
 # Enthought library imports
 from apptools.persistence.updater import __replacement_setstate__
 
 
 logger = logging.getLogger(__name__)
+
+
+def unbound_method(method, klass):
+    """
+    Python-version-agnostic unbound_method generator.
+
+    For Python 2, use MethodType. Python 3 doesn't have a separate
+    type for unbound methods; just return the method itself.
+    """
+    if sys.version_info < (3,):
+        return MethodType(method, None, klass)
+    else:
+        return method
+
 
 ##############################################################################
 # class 'NewUnpickler'
@@ -145,7 +159,7 @@ class VersionedUnpickler(NewUnpickler):
             # restore the original __setstate__ if necessary
             fn = getattr(klass, '__setstate_original__', False)
             if fn:
-                m = new.instancemethod(fn, None, klass)
+                m = unbound_method(fn, None, klass)
                 setattr(klass, '__setstate__', m)
 
         return klass
@@ -163,11 +177,11 @@ class VersionedUnpickler(NewUnpickler):
             self.backup_setstate(module, klass)
 
             # add the updater into the class
-            m = new.instancemethod(fn, None, klass)
+            m = unbound_method(fn, None, klass)
             setattr(klass, '__updater__', m)
 
             # hook up our __setstate__ which updates self.__dict__
-            m = new.instancemethod(__replacement_setstate__, None, klass)
+            m = unbound_method(__replacement_setstate__, None, klass)
             setattr(klass, '__setstate__', m)
 
         else:
@@ -192,7 +206,7 @@ class VersionedUnpickler(NewUnpickler):
 
             #logger.debug('renaming __setstate__ to %s' % name)
             method = getattr(klass, '__setstate__')
-            m = new.instancemethod(method, None, klass)
+            m = unbound_method(method, None, klass)
             setattr(klass, name, m)
 
         else:

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -11,7 +11,7 @@ from apptools.persistence.updater import __replacement_setstate__
 logger = logging.getLogger(__name__)
 
 
-def unbound_method(method, klass):
+def _unbound_method(method, klass):
     """
     Python-version-agnostic unbound_method generator.
 
@@ -159,7 +159,7 @@ class VersionedUnpickler(NewUnpickler):
             # restore the original __setstate__ if necessary
             fn = getattr(klass, '__setstate_original__', False)
             if fn:
-                m = unbound_method(fn, None, klass)
+                m = _unbound_method(fn, klass)
                 setattr(klass, '__setstate__', m)
 
         return klass
@@ -177,11 +177,11 @@ class VersionedUnpickler(NewUnpickler):
             self.backup_setstate(module, klass)
 
             # add the updater into the class
-            m = unbound_method(fn, None, klass)
+            m = _unbound_method(fn, klass)
             setattr(klass, '__updater__', m)
 
             # hook up our __setstate__ which updates self.__dict__
-            m = unbound_method(__replacement_setstate__, None, klass)
+            m = _unbound_method(__replacement_setstate__, klass)
             setattr(klass, '__setstate__', m)
 
         else:
@@ -206,7 +206,7 @@ class VersionedUnpickler(NewUnpickler):
 
             #logger.debug('renaming __setstate__ to %s' % name)
             method = getattr(klass, '__setstate__')
-            m = unbound_method(method, None, klass)
+            m = _unbound_method(method, klass)
             setattr(klass, name, m)
 
         else:


### PR DESCRIPTION
The new module was deprecated in Python 2.6, and doesn't exist in Python 3. This PR replaces its uses with the equivalent type calls.