### PR TITLE
Fix uses of print statement

### DIFF
--- a/apptools/io/tests/file_test_case.py
+++ b/apptools/io/tests/file_test_case.py
@@ -105,7 +105,7 @@ class FileTestCase(unittest.TestCase):
     def test_copy(self):
         """ file copy """
 
-        content = 'print "Hello World!"\n'
+        content = 'print("Hello World!")\n'
 
         f = File('data/foo.txt')
         self.assertEqual(f.exists, False)
@@ -153,7 +153,7 @@ class FileTestCase(unittest.TestCase):
     def test_create_file(self):
         """ file creation """
 
-        content = 'print "Hello World!"\n'
+        content = 'print("Hello World!")\n'
 
         f = File('data/foo.txt')
         self.assertEqual(f.exists, False)
@@ -171,7 +171,7 @@ class FileTestCase(unittest.TestCase):
     def test_delete(self):
         """ file deletion """
 
-        content = 'print "Hello World!"\n'
+        content = 'print("Hello World!")\n'
 
         f = File('data/foo.txt')
         self.assertEqual(f.exists, False)

--- a/apptools/logger/ring_buffer.py
+++ b/apptools/logger/ring_buffer.py
@@ -44,10 +44,10 @@ class RingBufferFull:
 # sample of use
 """x=RingBuffer(5)
 x.append(1); x.append(2); x.append(3); x.append(4)
-print x.__class__,x.get()
+print(x.__class__,x.get())
 x.append(5)
-print x.__class__,x.get()
+print(x.__class__,x.get())
 x.append(6)
-print x.data,x.get()
+print(x.data,x.get())
 x.append(7); x.append(8); x.append(9); x.append(10)
-print x.data,x.get()"""
+print(x.data,x.get())"""

--- a/apptools/naming/tests/pyfs_context_test_case.py
+++ b/apptools/naming/tests/pyfs_context_test_case.py
@@ -94,7 +94,7 @@ class PyFSContextTestCase(unittest.TestCase):
 
         # Bind a local file object.
         f = File(os.path.join(sub.path, 'foo.py'))
-        #f.create_file('print "foo!"\n')
+        #f.create_file('print("foo!")\n')
 
         context.bind('sub/foo.py', f)
         self.assertEqual(len(sub.list_bindings('')), 1)
@@ -209,7 +209,7 @@ class PyFSContextTestCase(unittest.TestCase):
 
         # Bind a file object.
         f = File(os.path.join(sub.path, 'foo.py'))
-        #f.create_file('print "foo!"\n')
+        #f.create_file('print("foo!")\n')
 
         context.bind('sub/foo.py', f)
         self.assertEqual(len(sub.list_bindings('')), 1)

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -172,7 +172,7 @@ class VersionedUnpickler(NewUnpickler):
 
         else:
             pass
-            #print 'No updater fn to worry about'
+            #print('No updater fn to worry about')
 
         return
 
@@ -214,7 +214,7 @@ class VersionedUnpickler(NewUnpickler):
         objects that are required for v1 and v2 do not have to exist they only
         need to be placeholders for the state during an upgrade.
         """
-        #print "importing %s %s" % (name, module)
+        #print("importing %s %s" % (name, module))
         module = __import__(module, globals(), locals(), [name])
         return vars(module)[name]
 

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -159,7 +159,7 @@ class TestRecorder(unittest.TestCase):
         toy.type = 'rat'
         self.assertEqual(tape.lines[-1], "child.toy.type = 'teddy'")
 
-        #print tape.script
+        #print(tape.script)
 
         # Stop recording.
         n = len(tape.lines)

--- a/docs/source/preferences/Preferences.rst
+++ b/docs/source/preferences/Preferences.rst
@@ -194,7 +194,7 @@ mechanism when the preferences are changed (either via the helper or via the
 preferences node directly::
 
   def listener(obj, trait_name, old, new):
-      print trait_name, old, new
+      print(trait_name, old, new)
 
   >>> helper.on_trait_change(listener)
   >>> helper.ratio = 0.75
@@ -332,10 +332,9 @@ If you are using Envisage to build your applications then you might also be
 interested in the `Preferences in Envisage`_ section.
 
 .. _API: api/index.html
-.. _ConfigObj: http://www.voidspace.org.uk/python/configobj.html 
+.. _ConfigObj: http://www.voidspace.org.uk/python/configobj.html
 .. _IPreferences: ../../enthought/preferences/i_preferences.py
 .. _Preferences: ../../enthought/preferences/preferences.py
 .. _PreferencesHelper: ../../enthought/preferences/preferences_helper.py
 .. _ScopedPreferences: ../../enthought/preferences/scoped_preferences.py
 .. _`Preferences in Envisage`: PreferencesInEnvisage.html
-

--- a/docs/source/scripting/introduction.rst
+++ b/docs/source/scripting/introduction.rst
@@ -30,7 +30,7 @@ that have Traits.  Technically the framework listens to all trait
 changes so will work outside a UI.  We do not document the full API
 here, the best place to look for that is the
 ``apptools.scripting.recorder`` module which is reasonably well
-documented.  We provide a high level overview of the library. 
+documented.  We provide a high level overview of the library.
 
 The quickest way to get started is to look at a small example.
 
@@ -43,7 +43,7 @@ A tour by example
 The following example is taken from the test suite.  Consider a set of
 simple objects organized in a hierarchy::
 
-    from traits.api import (HasTraits, Float, Instance, 
+    from traits.api import (HasTraits, Float, Instance,
             Str, List, Bool, HasStrictTraits, Tuple, Range, TraitPrefixMap,
             Trait)
     from apptools.scripting.api import (Recorder, recordable,
@@ -52,7 +52,7 @@ simple objects organized in a hierarchy::
     class Property(HasStrictTraits):
         color = Tuple(Range(0.0, 1.0), Range(0.0, 1.0), Range(0.0, 1.0))
         opacity = Range(0.0, 1.0, 1.0)
-        representation = Trait('surface', 
+        representation = Trait('surface',
                                TraitPrefixMap({'surface':2,
                                                'wireframe': 1,
                                                'points': 0}))
@@ -87,7 +87,7 @@ follows::
     p = Parent()
     c = Child()
     t = Toy()
-    c.toy = t 
+    c.toy = t
     p.children.append(c)
 
 Given this hierarchy, we'd like to be able to record a script.  To do
@@ -97,7 +97,7 @@ this we setup the recording infrastructure::
     # Create a recorder.
     r = Recorder()
     # Set the global recorder so the decorator works.
-    set_recorder(r)     
+    set_recorder(r)
     r.register(p)
     r.recording = True
 
@@ -121,7 +121,7 @@ Now lets test this out like so::
 
 To see what's been recorded do this::
 
-    print r.script
+    print(r.script)
 
 This prints::
 
@@ -137,7 +137,7 @@ location of a particular object in the object hierarchy.  For example,
 the path to the ``Toy`` instance in the hierarchy above is
 ``parent.children[0].toy``.  Since scripting with lists this way can be
 tedious, the recorder first instantiates the ``child``::
-    
+
     child = parent.children[0]
 
 Subsequent lines use the ``child`` attribute.  The recorder always tries
@@ -147,14 +147,14 @@ manner.
 To record a function or method call one must simply decorate the
 function/method with the ``recordable`` decorator.  Nested recordable
 functions are not recorded and trait changes are also not recorded if
-done inside a recordable function.  
+done inside a recordable function.
 
 .. note::
 
     1. It is very important to note that the global recorder must be set
        via the ``set_recorder`` method.  The ``recordable`` decorator
-       relies on this being set to work.  
-    
+       relies on this being set to work.
+
     2. The ``recordable`` decorator will work with plain Python classes
        and with functions too.
 
@@ -195,4 +195,3 @@ Here are a few advanced use cases.
 For more details on the recorder itself we suggest reading the module
 source code.  It is fairly well documented and with the above background
 should be enough to get you going.
-

--- a/examples/appscripting/example_script_window.py
+++ b/examples/appscripting/example_script_window.py
@@ -13,6 +13,8 @@
 #------------------------------------------------------------------------------
 
 
+from __future__ import print_function
+
 # Enthought library imports.
 from pyface.action.api import Action, Group, MenuManager
 from pyface.workbench.api import WorkbenchWindow
@@ -111,8 +113,8 @@ class ExampleScriptWindow(WorkbenchWindow):
         script = script_manager.script
 
         if script:
-            print script,
+            print(script, end="")
         else:
-            print "Script empty"
+            print("Script empty")
 
 #### EOF ######################################################################

--- a/examples/naming/simple.py
+++ b/examples/naming/simple.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     # Create an initial context.
     context = InitialContext(environment)
     context.path = os.getcwd()
-    print 'Context', context, context.path
-    print 'Names', context.list_names('')
+    print('Context', context, context.path)
+    print('Names', context.list_names(''))
 
 ##### EOF #####################################################################

--- a/examples/permissions/server/test_client.py
+++ b/examples/permissions/server/test_client.py
@@ -277,8 +277,8 @@ except xmlrpclib.Fault, e:
     else:
         msg = e.faultString[tail + 1:]
 
-    print "The call raised an exception: %s" % msg
+    print("The call raised an exception: %s" % msg)
     sys.exit(0)
 
 # Show the result.
-print "Result:", result
+print("Result:", result)

--- a/integrationtests/persistence/test_persistence.py
+++ b/integrationtests/persistence/test_persistence.py
@@ -25,7 +25,7 @@ class Foo:
         return '\n'.join(result)
 
     def __setstate__(self, state):
-        print 'calling setstate on the real Foo'
+        print('calling setstate on the real Foo')
         state['set'] = True
         self.__dict__.update(state)
 
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     import pickle
 
     obj = Foo0()
-    print obj
+    print(obj)
     t0 = pickle.dumps(obj) #.replace('Foo0', 'Foo')
     save('foo0.txt', t0)
 
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     save('foo3.txt', t3)
     '''
 
-    print '===================================================================='
+    print('====================================================================')
 
     from apptools.persistence.versioned_unpickler import VersionedUnpickler
     from update1 import Update1
@@ -75,10 +75,9 @@ if __name__ == '__main__':
     mod = sys.modules['integrationtests.persistence.update%d' % rev]
     klass = getattr(mod, 'Update%d' % rev)
     updater = klass()
-    print '%s %s' % (rev, updater)
+    print('%s %s' % (rev, updater))
 
     p = VersionedUnpickler(f, updater).load()
-    print p
-    print 'Restored version %s %s' % (p.lastname, p.firstname)
-    #print p.set
-
+    print(p)
+    print('Restored version %s %s' % (p.lastname, p.firstname))
+    #print(p.set)

--- a/integrationtests/persistence/update1.py
+++ b/integrationtests/persistence/update1.py
@@ -5,7 +5,7 @@ from apptools.persistence.updater import Updater
 
 def cleanup_foo(self, state):
 
-    print 'cleaning up Foo0'
+    print('cleaning up Foo0')
     state['firstname'] = state['prenom']
     state['lastname'] = state['surnom']
 
@@ -13,7 +13,7 @@ def cleanup_foo(self, state):
     del state['surnom']
 
     '''for key in state:
-        print '%s state ---> %s' % (key, state[key])
+        print('%s state ---> %s' % (key, state[key]))
     '''
 
     #self.__setstate_original__(state)
@@ -21,7 +21,7 @@ def cleanup_foo(self, state):
 
 
 def update_project(self, state):
-    print 'updating to v1'
+    print('updating to v1')
     metadata = state['metadata']
     metadata['version'] = 1
     metadata['diesel'] = 'E300TD'

--- a/integrationtests/persistence/update2.py
+++ b/integrationtests/persistence/update2.py
@@ -5,7 +5,7 @@ from apptools.persistence.updater import Updater
 
 
 def update_project(self, state):
-    print 'updating to v2'
+    print('updating to v2')
     metadata = state['metadata']
     metadata['version'] =  2
     metadata['updater'] = 22

--- a/integrationtests/persistence/update3.py
+++ b/integrationtests/persistence/update3.py
@@ -5,7 +5,7 @@ from apptools.persistence.updater import Updater
 
 
 def update_project(self, state):
-    print 'updating to v3'
+    print('updating to v3')
     metadata = state['metadata']
     metadata['version'] = 3
     metadata['finished'] = True


### PR DESCRIPTION
This PR fixes some remaining uses of the Python 2 `print` statement.

For now, the source should remain compatible with both Python 2 and Python 3, but some of these `print`s will have changed behaviour in Python 2, printing a representation of a tuple instead of space-separated elements. The Python 2 support is going to be short-lived enough that this isn't worth fixing.