### PR TITLE
Don't finish fast for CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       env: RUNTIME=3.5
     - os: osx
       env: RUNTIME=3.6
-  fast_finish: true
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ environment:
     - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
-matrix:
-  fast_finish: true
-
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt


### PR DESCRIPTION
The "finish fast" setting is getting in the way of PR failure diagnoses; this PR removes it.