### PR TITLE
Pin pytables to prevent osx segfaults

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -94,7 +94,9 @@ dependencies = {
     "traitsui",
     "configobj",
     "coverage",
-    "pytables",
+    # This version is pinned due to the latest build causing failures on the
+    # travis CI see issue traitsui/#1156.
+    "pytables==3.5.1-4",
     "pandas",
     "pyface",
     "nose",


### PR DESCRIPTION
Until we figure out a better solution or we get a new build of pytables, we need to pin pytables to prevent ci/osx from crashing.  https://github.com/enthought/traitsui/issues/1156