### PR TITLE
Add source click option used on cron jobs - only use python 3.6 on CI - move OSX CI to appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ env:
   global:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
-    - TRAVIS_EVENT_TYPE='cron' 
 
 matrix:
   include:
     - env: RUNTIME=3.6
-    - os: osx
-      env: RUNTIME=3.6
-    fast_finish: true
+  fast_finish: true
 
 cache:
   directories:
@@ -23,7 +20,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
   - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ before_install:
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
-  - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
   - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
-      edm run -- python etstool.py install ${RUNTIME} --source || exit;
+      edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit;
+    else
+      edm run -- python etstool.py install --runtime=${RUNTIME} || exit;
     fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,7 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=2.7
-    - env: RUNTIME=3.5
     - env: RUNTIME=3.6
-    - os: osx
-      env: RUNTIME=2.7
-    - os: osx
-      env: RUNTIME=3.5
     - os: osx
       env: RUNTIME=3.6
 
@@ -33,7 +27,7 @@ before_install:
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
   - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
-      edm run -- python etstool.py install --runtime=3.6 --source || exit;
+      edm run -- python etstool.py install ${RUNTIME} --source || exit;
     fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit; fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
       edm run -- python etstool.py install --runtime=${RUNTIME} || exit;
     fi
 script:
-  - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
+  - edm run -- python -X faulthandler etstool.py test --runtime=${RUNTIME} || exit
 
 after_success:
   - edm run -- coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
-  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit; fi
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' AND ${RUNTIME} == 3.6]]; then
+      edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit;
+    fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
+    - TRAVIS_EVENT_TYPE='cron' 
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
-  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' AND ${RUNTIME} == 3.6]]; then
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' && ${RUNTIME} == 3.6]]; then
       edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit;
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
       edm run -- python etstool.py install --runtime=${RUNTIME} || exit;
     fi
 script:
-  - edm run -- python -X faulthandler etstool.py test --runtime=${RUNTIME} || exit
+  - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
 
 after_success:
   - edm run -- coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - env: RUNTIME=3.6
     - os: osx
       env: RUNTIME=3.6
+    fast_finish: true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
-  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' && ${RUNTIME} == 3.6]]; then
-      edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit;
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
+      edm run -- python etstool.py install --runtime=3.6 --source || exit;
     fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
 
   matrix:
 
-    - RUNTIME: '2.7'
-    - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   global:
     PYTHONUNBUFFERED: "1"
     INSTALL_EDM_VERSION: "2.0.0"
+    APPVEYOR_YML_DISABLE_PS_LINUX: true
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
 build: false
+image:
+  - MacOS
+  - Visual Studio 2019
+
 environment:
 
   global:
@@ -12,17 +16,29 @@ environment:
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
+  - '${HOME}/cache -> appveyor-clean-cache.txt'
 
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
+  # note that on osx the .cache folder is owned by root
+  # and we cannot create files there.
+  - sh: export PATH="${PATH}:/usr/local/bin"
+  - sh: export XDG_CACHE_HOME="${HOME}/cache"
+  - sh: export LC_ALL=en_US.UTF-8
+  - sh: export LANG=en_US.UTF-8
+  - sh: mkdir -p "${HOME}/cache/download"
+  - sh: sysctl -n machdep.cpu.brand_string
 
 install:
-  - install-edm-windows.cmd
+  - cmd: install-edm-windows.cmd
+  - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - edm run -- python etstool.py install --runtime=%runtime%
+  - sh: edm run -- python etstool.py install --runtime="${RUNTIME}"
+  - cmd: edm run -- python etstool.py install --runtime=%runtime%
 test_script:
-  - edm run -- python etstool.py test --runtime=%runtime%
+  - sh: edm run -- python etstool.py test --runtime="${RUNTIME}"
+  - cmd: edm run -- python etstool.py test --runtime=%runtime%
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/etstool.py
+++ b/etstool.py
@@ -104,6 +104,17 @@ dependencies = {
 }
 
 
+# Dependencies we install from source for cron tests
+source_dependencies = {
+    "pyface",
+    "traits",
+    "traitsui",
+}
+
+
+github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
+
+
 @click.group()
 def cli():
     pass
@@ -112,7 +123,12 @@ def cli():
 @cli.command()
 @click.option('--runtime', default='3.5')
 @click.option('--environment', default=None)
-def install(runtime, environment):
+@click.option(
+    "--source/--no-source",
+    default=False,
+    help="Install ETS packages from source",
+)
+def install(runtime, environment, source):
     """ Install project and dependencies into a clean EDM environment.
 
     """
@@ -130,6 +146,26 @@ def install(runtime, environment):
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
+
+    if source:
+        # Remove EDM ETS packages and install them from source
+        cmd_fmt = (
+            "edm plumbing remove-package "
+            "--environment {environment} --force "
+        )
+        commands = [cmd_fmt + source_pkg for source_pkg in source_dependencies]
+        execute(commands, parameters)
+        source_pkgs = [
+            github_url_fmt.format(pkg) for pkg in source_dependencies
+        ]
+        commands = [
+            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
+            for pkg in source_pkgs
+        ]
+        commands = [
+            "edm run -e {environment} -- " + command for command in commands
+        ]
+        execute(commands, parameters)
     click.echo('Done install')
 
 

--- a/etstool.py
+++ b/etstool.py
@@ -180,7 +180,7 @@ def test(runtime, environment):
     environ = {}
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- coverage run -p -m nose.core -v apptools --nologcapture"]
+        "edm run -e {environment} -- python -X faulthandler -m coverage run -p -m nose.core -v apptools --nologcapture"]
 
     # We run in a tempdir to avoid accidentally picking up wrong apptools
     # code from a local dir.  We need to ensure a good .coveragerc is in

--- a/etstool.py
+++ b/etstool.py
@@ -180,7 +180,7 @@ def test(runtime, environment):
     environ = {}
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- python -X faulthandler -m coverage run -p -m nose.core -v apptools --nologcapture"]
+        "edm run -e {environment} -- coverage run -p -m nose.core -v apptools --nologcapture"]
 
     # We run in a tempdir to avoid accidentally picking up wrong apptools
     # code from a local dir.  We need to ensure a good .coveragerc is in

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -5,7 +5,7 @@ set -e
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
     local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
-    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+    local EDM_INSTALLER_PATH="${HOME}/cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
         curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"


### PR DESCRIPTION
This PR makes it so that cron jobs install pyface, traitsui, and traits from source by adding a --source click option used in the install function in etstool.py.
It also removes the python 2.7 and 3.5 builds from CI as we will be dropping their support soon.

Additionally, it fixes #152 my moving the OSX CI onto appveyor and off of travis. 

This cron jobs follow what is done in other ets projects (e.g https://github.com/enthought/envisage/blob/8245931f7e3dfcb6513bfb7dc2ae9b10ca6f89a1/etstool.py#L255-L273)