### PR TITLE
Use Python 3.6 as the default runtime in etstool module

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -110,7 +110,7 @@ def cli():
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--environment', default=None)
 def install(runtime, environment):
     """ Install project and dependencies into a clean EDM environment.
@@ -134,7 +134,7 @@ def install(runtime, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--environment', default=None)
 def test(runtime, environment):
     """ Run the test suite in a given environment.
@@ -157,7 +157,7 @@ def test(runtime, environment):
     click.echo('Done test')
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='6')
 @click.option('--environment', default=None)
 def docs(runtime, environment):
     """ Build HTML documentation. """
@@ -184,7 +184,7 @@ def docs(runtime, environment):
     execute(commands, parameters)
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--environment', default=None)
 def cleanup(runtime, environment):
     """ Remove a development environment.
@@ -200,7 +200,7 @@ def cleanup(runtime, environment):
 
 
 @cli.command(name='test-clean')
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 def test_clean(runtime):
     """ Run tests in a clean environment, cleaning up afterwards
 
@@ -213,7 +213,7 @@ def test_clean(runtime):
         cleanup(args=args, standalone_mode=False)
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--environment', default=None)
 def update(runtime, environment):
     """ Update/Reinstall package into environment.


### PR DESCRIPTION
fixes #149 
by simply bumping 3.5 to 3.6 in click options.