### PR TITLE
Remove automated code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ script:
 
 after_success:
   - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov
 
 notifications:
   email:

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,6 @@ apptools: application tools
     :target: https://travis-ci.org/enthought/apptools
     :alt: Build status
 
-.. image:: https://codecov.io/github/enthought/apptools/coverage.svg?branch=master
-    :target: https://codecov.io/github/enthought/apptools?branch=master
-    :alt: Coverage report
-
 Documentation: http://docs.enthought.com/apptools
 
 Source Code: http://www.github.com/enthought/apptools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,5 +42,3 @@ test_script:
   - cmd: edm run -- python etstool.py test --runtime=%runtime%
 on_success:
   - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov


### PR DESCRIPTION
As with other ETS projects, the automated code coverage has not proved reliable or useful. This PR removes it, along with the associated badge in the README.