### PR TITLE
Fix assert deprecation and resource warnings in testsuite

### DIFF
--- a/apptools/io/tests/test_file.py
+++ b/apptools/io/tests/test_file.py
@@ -161,7 +161,8 @@ class FileTestCase(unittest.TestCase):
         # Create the file.
         f.create_file(content)
         self.assertEqual(f.exists, True)
-        self.assertEqual(open(f.path).read(), content)
+        with open(f.path) as file:
+            self.assertEqual(file.read(), content)
 
         # Try to create it again.
         self.assertRaises(ValueError, f.create_file, content)

--- a/apptools/io/tests/test_file.py
+++ b/apptools/io/tests/test_file.py
@@ -58,7 +58,7 @@ class FileTestCase(unittest.TestCase):
         # Properties of a non-existent file.
         f = File('data/bogus.xx')
 
-        self.assert_(os.path.abspath(os.path.curdir) in f.absolute_path)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.absolute_path)
         self.assertEqual(f.children, None)
         self.assertEqual(f.ext, '.xx')
         self.assertEqual(f.exists, False)
@@ -70,14 +70,14 @@ class FileTestCase(unittest.TestCase):
         self.assertEqual(f.name, 'bogus')
         self.assertEqual(f.parent.path, 'data')
         self.assertEqual(f.path, 'data/bogus.xx')
-        self.assert_(os.path.abspath(os.path.curdir) in f.url)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.url)
         self.assertEqual(str(f), 'File(%s)' % f.path)
 
         # Properties of an existing file.
         f = File('data/foo.txt')
         f.create_file()
 
-        self.assert_(os.path.abspath(os.path.curdir) in f.absolute_path)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.absolute_path)
         self.assertEqual(f.children, None)
         self.assertEqual(f.ext, '.txt')
         self.assertEqual(f.exists, True)
@@ -89,7 +89,7 @@ class FileTestCase(unittest.TestCase):
         self.assertEqual(f.name, 'foo')
         self.assertEqual(f.parent.path, 'data')
         self.assertEqual(f.path, 'data/foo.txt')
-        self.assert_(os.path.abspath(os.path.curdir) in f.url)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.url)
 
         # Make it readonly.
         os.chmod(f.path, stat.S_IRUSR)

--- a/apptools/io/tests/test_folder.py
+++ b/apptools/io/tests/test_folder.py
@@ -59,7 +59,7 @@ class FolderTestCase(unittest.TestCase):
         # Properties of a non-existent folder.
         f = File('data/bogus')
 
-        self.assert_(os.path.abspath(os.path.curdir) in f.absolute_path)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.absolute_path)
         self.assertEqual(f.children, None)
         self.assertEqual(f.ext, '')
         self.assertEqual(f.exists, False)
@@ -71,14 +71,14 @@ class FolderTestCase(unittest.TestCase):
         self.assertEqual(f.name, 'bogus')
         self.assertEqual(f.parent.path, 'data')
         self.assertEqual(f.path, 'data/bogus')
-        self.assert_(os.path.abspath(os.path.curdir) in f.url)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.url)
         self.assertEqual(str(f), 'File(%s)' % f.path)
 
         # Properties of an existing folder.
         f = File('data/sub')
         f.create_folder()
 
-        self.assert_(os.path.abspath(os.path.curdir) in f.absolute_path)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.absolute_path)
         self.assertEqual(len(f.children), 0)
         self.assertEqual(f.ext, '')
         self.assertEqual(f.exists, True)
@@ -90,7 +90,7 @@ class FolderTestCase(unittest.TestCase):
         self.assertEqual(f.name, 'sub')
         self.assertEqual(f.parent.path, 'data')
         self.assertEqual(f.path, 'data/sub')
-        self.assert_(os.path.abspath(os.path.curdir) in f.url)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.url)
 
         # Make it readonly.
         os.chmod(f.path, stat.S_IRUSR)
@@ -108,7 +108,7 @@ class FolderTestCase(unittest.TestCase):
         init = File('data/package/__init__.py')
         init.create_file()
 
-        self.assert_(os.path.abspath(os.path.curdir) in f.absolute_path)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.absolute_path)
         self.assertEqual(len(f.children), 1)
         self.assertEqual(f.ext, '')
         self.assertEqual(f.exists, True)
@@ -120,7 +120,7 @@ class FolderTestCase(unittest.TestCase):
         self.assertEqual(f.name, 'package')
         self.assertEqual(f.parent.path, 'data')
         self.assertEqual(f.path, 'data/package')
-        self.assert_(os.path.abspath(os.path.curdir) in f.url)
+        self.assertTrue(os.path.abspath(os.path.curdir) in f.url)
 
         return
 

--- a/apptools/naming/tests/test_context.py
+++ b/apptools/naming/tests/test_context.py
@@ -62,7 +62,7 @@ class ContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, Context))
+        self.assertTrue(isinstance(sub, Context))
 
         # Make sure that the sub-context is empty.
         self.assertEqual(len(sub.list_bindings('')), 0)
@@ -93,7 +93,7 @@ class ContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, Context))
+        self.assertTrue(isinstance(sub, Context))
 
         # Make sure that the sub-context is empty.
         self.assertEqual(len(sub.list_bindings('')), 0)
@@ -151,7 +151,7 @@ class ContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, Context))
+        self.assertTrue(isinstance(sub, Context))
 
         # Make sure that the sub-context is empty.
         self.assertEqual(len(sub.list_bindings('')), 0)

--- a/apptools/naming/tests/test_dir_context.py
+++ b/apptools/naming/tests/test_dir_context.py
@@ -43,7 +43,7 @@ class DirContextTestCase(ContextTestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, DirContext))
+        self.assertTrue(isinstance(sub, DirContext))
 
         #### Generic name resolution tests ####
 
@@ -78,7 +78,7 @@ class DirContextTestCase(ContextTestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, DirContext))
+        self.assertTrue(isinstance(sub, DirContext))
 
         #### Generic name resolution tests ####
 

--- a/apptools/naming/tests/test_pyfs_context.py
+++ b/apptools/naming/tests/test_pyfs_context.py
@@ -109,7 +109,7 @@ class PyFSContextTestCase(unittest.TestCase):
         f = PyFSContext(path='other')
         context.bind('sub/other', f)
         self.assertEqual(len(sub.list_bindings('')), 3)
-        self.assert_(f.path in context.lookup('sub/other').path)
+        self.assertTrue(f.path in context.lookup('sub/other').path)
 
         # Bind a Python object.
         context.bind('sub/a', 1)
@@ -248,7 +248,7 @@ class PyFSContextTestCase(unittest.TestCase):
         # Create a sub-context.
         a = context.create_subcontext('sub/a')
         self.assertEqual(len(sub.list_bindings('')), 1)
-        self.assert_(os.path.isdir(os.path.join(sub.path, 'a')))
+        self.assertTrue(os.path.isdir(os.path.join(sub.path, 'a')))
 
         # Try to bind it again.
         self.assertRaises(
@@ -277,7 +277,7 @@ class PyFSContextTestCase(unittest.TestCase):
         # Destroy it.
         context.destroy_subcontext('sub/a')
         self.assertEqual(len(sub.list_bindings('')), 0)
-        self.assert_(not os.path.isdir(os.path.join(sub.path, 'a')))
+        self.assertTrue(not os.path.isdir(os.path.join(sub.path, 'a')))
 
         # Bind a name.
         context.bind('sub/a', 1)
@@ -303,7 +303,7 @@ class PyFSContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, DirContext))
+        self.assertTrue(isinstance(sub, DirContext))
 
         #### Generic name resolution tests ####
 
@@ -338,7 +338,7 @@ class PyFSContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, DirContext))
+        self.assertTrue(isinstance(sub, DirContext))
 
         #### Generic name resolution tests ####
 
@@ -389,7 +389,7 @@ class PyFSContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup('sub')
-        self.assert_(isinstance(sub, DirContext))
+        self.assertTrue(isinstance(sub, DirContext))
 
         self.assertEqual(context.namespace_name, 'data')
         self.assertEqual(sub.namespace_name, 'data/sub')

--- a/apptools/preferences/tests/example.ini
+++ b/apptools/preferences/tests/example.ini
@@ -3,7 +3,7 @@ bgcolor = blue
 width = 50
 ratio = 1.0
 visible = True
-description = 'acme ui'
+description = acme ui
 offsets = "[1, 2, 3, 4]"
 names = "['joe', 'fred', 'jane']"
 

--- a/apptools/preferences/tests/example.ini
+++ b/apptools/preferences/tests/example.ini
@@ -3,7 +3,7 @@ bgcolor = blue
 width = 50
 ratio = 1.0
 visible = True
-description = acme ui
+description = 'acme ui'
 offsets = "[1, 2, 3, 4]"
 names = "['joe', 'fred', 'jane']"
 

--- a/apptools/preferences/tests/test_py_config_file.py
+++ b/apptools/preferences/tests/test_py_config_file.py
@@ -101,7 +101,7 @@ class PyConfigFileTestCase(unittest.TestCase):
 
         config.save(tmp)
         try:
-            self.assert_(os.path.exists(tmp))
+            self.assertTrue(os.path.exists(tmp))
 
             # Make sure we can read the file back in and that we get the same
             # values!

--- a/apptools/type_manager/tests/test_type_manager.py
+++ b/apptools/type_manager/tests/test_type_manager.py
@@ -114,7 +114,7 @@ class TypeManagerTestCase(unittest.TestCase):
         bar = self.type_manager.object_as(b, Bar)
 
         # The type manager should simply return the same object.
-        self.assert_(bar is b)
+        self.assertTrue(bar is b)
 
         return
 


### PR DESCRIPTION
fixes #162 

This PR simply replaces all occurrences of `self.assert_(` with `self.assertTrue(` to avoid deprecation warnings, and also avoids a ResourceWarning for not closing a file by using a `with` statement when opening the file.  

One thing I noticed when making the `assertTrue` fix was that there are tons of places which use 
`assertEqual(____, True)` or `assertEqual(____, None)` or `assertEqual(____, False)`.  Rather than just `assertTrue`, `assertIsNone` or `assertFalse`.  Similarly there are many places were we have `assertTrue(isinstance(____,____))` instead of `assertIsInstance(__, ___)` etc.  These are extremely minor, just something we may want to clean up 