### PR TITLE
TST: Switch on default warning flag for CI test command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -181,8 +181,8 @@ def test(runtime, environment):
     environ = {}
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        ("edm run -e {environment} -- python -W default -m coverage run -p -m "
-         "unittest discover -v apptools")
+        "edm run -e {environment} -- python -W default -m coverage run -p -m "
+         "unittest discover -v apptools"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong apptools

--- a/etstool.py
+++ b/etstool.py
@@ -182,7 +182,7 @@ def test(runtime, environment):
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
         "edm run -e {environment} -- python -W default -m coverage run -p -m "
-         "unittest discover -v apptools"
+        "unittest discover -v apptools"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong apptools

--- a/etstool.py
+++ b/etstool.py
@@ -181,7 +181,9 @@ def test(runtime, environment):
     environ = {}
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v apptools"]
+        ("edm run -e {environment} -- python -W default -m coverage run -p -m "
+         "unittest discover -v apptools")
+    ]
 
     # We run in a tempdir to avoid accidentally picking up wrong apptools
     # code from a local dir.  We need to ensure a good .coveragerc is in


### PR DESCRIPTION
Fixes #150 

This change is lifted directly from https://github.com/enthought/traitsui/pull/1059.  It simply adds `-W default` flag.