### PR TITLE
Require pandas on the only method that requires it

### DIFF
--- a/apptools/_testing/__init__.py
+++ b/apptools/_testing/__init__.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+"""
+Utilities for apptools internal tests.
+"""

--- a/apptools/_testing/optional_dependencies.py
+++ b/apptools/_testing/optional_dependencies.py
@@ -1,0 +1,47 @@
+# (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Utilities for handling optional dependencies so that tests for
+optional features can be skipped gracefully.
+"""
+import importlib
+import unittest
+
+
+def optional_import(name):
+    """
+    Optionally import a module, returning None if that module is unavailable.
+
+    Parameters
+    ----------
+    name : Str
+        The name of the module being imported.
+
+    Returns
+    -------
+    None or module
+        None if the module is not available, and the module otherwise.
+
+    """
+    try:
+        module = importlib.import_module(name)
+    except ImportError:
+        return None
+    else:
+        return module
+
+
+numpy = optional_import("numpy")
+requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
+
+pandas = optional_import("pandas")
+requires_pandas = unittest.skipIf(pandas is None, "Pandas not available")
+
+tables = optional_import("tables")
+requires_tables = unittest.skipIf(tables is None, "PyTables not available")

--- a/apptools/io/h5/table_node.py
+++ b/apptools/io/h5/table_node.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pandas import DataFrame
+
 import six
 from tables.table import Table as PyTablesTable
 
@@ -115,7 +115,10 @@ class H5TableNode(object):
         """ Return table data as a pandas `DataFrame`.
 
         XXX: This does not work if the table contains a multidimensional column
+
+        This method requires pandas to have been installed in the environment.
         """
+        from pandas import DataFrame
         # Slicing rows gives a numpy struct array, which DataFrame understands.
         return DataFrame(self.ix[:])
 

--- a/apptools/io/h5/tests/test_table_node.py
+++ b/apptools/io/h5/tests/test_table_node.py
@@ -1,33 +1,42 @@
 import unittest
 
-import numpy as np
-from numpy.testing import assert_allclose
-from pandas import DataFrame
+from apptools._testing.optional_dependencies import (
+    numpy as np,
+    pandas,
+    tables,
+    requires_numpy,
+    requires_pandas,
+    requires_tables,
+)
 
-from ..table_node import H5TableNode
-from .utils import temp_h5_file
+if np is not None and tables is not None:
+    from ..table_node import H5TableNode
+    from .utils import temp_h5_file
 
 
 NODE = '/table_node'
 
 
+@requires_numpy
+@requires_tables
 class TableNodeTestCase(unittest.TestCase):
+
     def test_basics(self):
         description = [('a', np.float64), ('b', np.float64)]
         with temp_h5_file() as h5:
             h5table = H5TableNode.add_to_h5file(h5, NODE, description)
             h5table.append({'a': [1, 2], 'b': [3, 4]})
 
-            assert_allclose(h5table['a'], [1, 2])
-            assert_allclose(h5table['b'], [3, 4])
+            np.testing.assert_allclose(h5table['a'], [1, 2])
+            np.testing.assert_allclose(h5table['b'], [3, 4])
 
         dtype_description = np.dtype([('c', 'f4'), ('d', 'f4')])
         with temp_h5_file() as h5:
             h5table = H5TableNode.add_to_h5file(h5, NODE, dtype_description)
             h5table.append({'c': [1.2, 3.4], 'd': [5.6, 7.8]})
 
-            assert_allclose(h5table['c'], [1.2, 3.4])
-            assert_allclose(h5table['d'], [5.6, 7.8])
+            np.testing.assert_allclose(h5table['c'], [1.2, 3.4])
+            np.testing.assert_allclose(h5table['d'], [5.6, 7.8])
 
             assert len(repr(h5table)) > 0
 
@@ -36,9 +45,9 @@ class TableNodeTestCase(unittest.TestCase):
         with temp_h5_file() as h5:
             h5table = H5TableNode.add_to_h5file(h5, NODE, description)
             h5table.append({'a': [1, 2], 'b': [3, 4]})
-            assert_allclose(h5table['a'], (1, 2))
-            assert_allclose(h5table[['b', 'a']], [(3, 1),
-                                                (4, 2)])
+            np.testing.assert_allclose(h5table['a'], (1, 2))
+            np.testing.assert_allclose(
+                h5table[['b', 'a']], [(3, 1), (4, 2)])
 
     def test_keys(self):
         description = [('hello', 'int'), ('world', 'int'), ('Qux1', 'bool')]
@@ -47,14 +56,15 @@ class TableNodeTestCase(unittest.TestCase):
             h5table = H5TableNode.add_to_h5file(h5, NODE, description)
             assert set(h5table.keys()) == keys
 
+    @requires_pandas
     def test_to_dataframe(self):
         description = [('a', np.float64)]
         with temp_h5_file() as h5:
             h5table = H5TableNode.add_to_h5file(h5, NODE, description)
             h5table.append({'a': [1, 2, 3]})
             df = h5table.to_dataframe()
-            assert isinstance(df, DataFrame)
-            assert_allclose(df['a'], h5table['a'])
+            assert isinstance(df, pandas.DataFrame)
+            np.testing.assert_allclose(df['a'], h5table['a'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently `apptools.io.h5` requires `pandas` to be a runtime requirement because `DataFrame` is imported and then used ONCE in `H5TableNode.to_dataframe`.

The `to_dataframe` merely instantiates `DataFrame` with the public attribute `ix` and return that DataFrame. It is fair to assume that if one requires this `to_dataframe`, they should already have pandas in their environment. It is a bit overkill to require pandas to be installed, especially if `to_dataframe` is not actually required in user code.

This PR moves the import of `pandas` in the single method that requires it. And fixes the tests for H5TableNode so that they are skipped if NumPy and PyTables are not available.  The latter contributes towards #99 (but it does not close the issue).