### PR TITLE
Bump major version for the next release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import re
 import subprocess
 from setuptools import setup, find_packages
 
-MAJOR = 4
-MINOR = 6
+MAJOR = 5
+MINOR = 0
 MICRO = 0
 
 IS_RELEASED = False


### PR DESCRIPTION
#172, #173, #175 will bring about backward incompatible changes: removal of packages.

This PR bumps the version to 5.0.0.dev0, which is equivalent to 4.6.0.dev0 as far as version comparison goes if we will never have a 4.6.0 (I think?). This will do two things (1) signal the master branch is preparing itself for a major release and (2) when we release, we don't accidentally release 4.6.0.