### PR TITLE
Update changelog with entries for PRs removing entire subpackages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Apptools CHANGELOG
 ==================
 
+Version 5.0.0
+~~~~~~~~~~~~~
+
+Released : XX XX XXXX
+
+* Remove appscripting subpackage (#172)
+* Remove template subpackage (#173)
+* Remove permissions subpackage (#175)
+
 Version 4.5.0
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
In PRs #172, #173, and #175 the `appscripting`, `template`, and `permissions` subpackages were removed.  This PR simply updates the changelog to record these changes for the 5.0.0 release. 