### PR TITLE
Remove commented out code

### DIFF
--- a/apptools/help/help_plugin/help_plugin.py
+++ b/apptools/help/help_plugin/help_plugin.py
@@ -272,13 +272,3 @@ class HelpPlugin(Plugin):
                              ) for example in self.help_examples
                 ])
         return pages
-
-    #my_help_demos = List(contributes_to=HELP_DEMOS)
-    #def _my_help_demos_default(self):
-    #    return [HelpCode( preferences_path=PKG + '.TraitsDemo'),
-    #           ]
-
-    #my_help_examples = List(contributes_to=HELP_EXAMPLES)
-    #def _my_help_examples_default(self):
-    #    return [HelpCode( preferences_path=PKG + '.AcmeLab'),
-    #           ]


### PR DESCRIPTION
This PR simply deletes code that was commented out from `apptools.help.help_plugin.help_plugin.py`.

Robert Martin told me to basically blindly delete any commented out code without trying to understand it.