### PR TITLE
Use the latest EDM version (>=3.0.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=2.0.0
+    - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=3.0.1
+    - INSTALL_EDM_VERSION=3.1.1
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "3.0.1"
+    INSTALL_EDM_VERSION: "3.1.1"
     APPVEYOR_YML_DISABLE_PS_LINUX: true
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "2.0.0"
+    INSTALL_EDM_VERSION: "3.0.1"
     APPVEYOR_YML_DISABLE_PS_LINUX: true
 
   matrix:


### PR DESCRIPTION
Fixes #154 

This PR simply bumps the version number for the edm version from 2.0.0 to 3.0.1 in the appveyor and travis yml files.