### PR TITLE
Dont import unittest from traits

### DIFF
--- a/apptools/selection/tests/test_list_selection.py
+++ b/apptools/selection/tests/test_list_selection.py
@@ -1,6 +1,6 @@
-import numpy
+import unittest
 
-from traits.testing.unittest_tools import unittest
+import numpy
 
 from apptools.selection.api import ListSelection
 

--- a/apptools/selection/tests/test_selection_service.py
+++ b/apptools/selection/tests/test_selection_service.py
@@ -1,5 +1,6 @@
+import unittest
+
 from traits.api import Any, Event, HasTraits, List, provides, Str
-from traits.testing.unittest_tools import unittest
 
 from apptools.selection.api import (
     IDConflictError, ISelection, ISelectionProvider, ListenerNotConnectedError,

--- a/apptools/undo/tests/test_command_stack.py
+++ b/apptools/undo/tests/test_command_stack.py
@@ -13,8 +13,8 @@
 # -----------------------------------------------------------------------------
 
 from contextlib import contextmanager
+import unittest
 
-from traits.testing.unittest_tools import unittest
 from apptools.undo.api import CommandStack, UndoManager
 from apptools.undo.tests.testing_commands import SimpleCommand, UnnamedCommand
 


### PR DESCRIPTION
This PR updates `unittest` imports to use the `unittest` standard library package directly instead of importing from `traits` testing utility. This might have been done earlier to provide compatibility between unittest2 on python 2 and unittest on python 3 but now that we are python 3 only, this is not needed.

Note additionally that the traits module has long been updated to only export the `unittest` standard library - https://github.com/enthought/traits/blob/master/traits/testing/unittest_tools.py

contributes towards #120 