### PR TITLE
Remove mock compatibility imports on Python 2

### DIFF
--- a/apptools/logger/agent/tests/test_attachments.py
+++ b/apptools/logger/agent/tests/test_attachments.py
@@ -4,13 +4,7 @@ import os
 import shutil
 import tempfile
 import unittest
-
-try:
-    # On Python 3, mock is part of the standard library,
-    from unittest import mock
-except ImportError:
-    # Whereas on Python 2 it is not.
-    import mock
+from unittest import mock
 
 from apptools.logger.agent.attachments import Attachments
 

--- a/apptools/logger/plugin/tests/test_logger_service.py
+++ b/apptools/logger/plugin/tests/test_logger_service.py
@@ -1,12 +1,6 @@
 from email.mime.multipart import MIMEMultipart
 import unittest
-
-try:
-    # On Python 3, mock is part of the standard library,
-    from unittest import mock
-except ImportError:
-    # Whereas on Python 2 it is not.
-    import mock
+from unittest import mock
 
 from apptools.logger.plugin.logger_service import LoggerService
 

--- a/etstool.py
+++ b/etstool.py
@@ -99,7 +99,6 @@ dependencies = {
     "pytables",
     "pandas",
     "pyface",
-    "mock",
     "enthought_sphinx_theme",
     "sphinx",
 }


### PR DESCRIPTION
This PR removes the compatibilty layer for `mock` imports for python 2 vs python 3 compatibility, now that the package is moving towards python 3 only. This PR also removes `mock` as a dependency from the `etstool` development utility.

contributes towards #120 