### PR TITLE
Remove bare returns in preferences tests

### DIFF
--- a/apptools/preferences/tests/py_config_file.py
+++ b/apptools/preferences/tests/py_config_file.py
@@ -45,8 +45,6 @@ class PyConfigFile(dict):
         if file_or_filename is not None:
             self.load(file_or_filename)
 
-        return
-
     ###########################################################################
     # 'PyConfigFile' interface.
     ###########################################################################
@@ -92,8 +90,6 @@ class PyConfigFile(dict):
 
         f.close()
 
-        return
-
     def save(self, file_or_filename):
         """ Save the configuration to a file.
 
@@ -110,8 +106,6 @@ class PyConfigFile(dict):
             self._write_section(f, section_name, section_data)
 
         f.close()
-
-        return
 
     ###########################################################################
     # Private interface.
@@ -182,8 +176,6 @@ class PyConfigFile(dict):
         namespace = self._get_namespace(section_name)
         namespace.__dict__.update(section)
 
-        return
-
     def _write_section(self, f, section_name, section_data):
         """ Write a section to a file. """
 
@@ -193,8 +185,6 @@ class PyConfigFile(dict):
             f.write('%s = %s\n' % (name, repr(value)))
 
         f.write('\n')
-
-        return
 
     ###########################################################################
     # Debugging interface.
@@ -206,8 +196,6 @@ class PyConfigFile(dict):
         for name, value in self._namespaces.items():
             print('Namespace:', name)
             value.pretty_print('  ')
-
-        return
 
 
 ###############################################################################
@@ -258,5 +246,3 @@ class _Namespace(object):
 
             else:
                 print(indent, name, ':', value)
-
-        return

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -45,12 +45,8 @@ class PreferenceBindingTestCase(unittest.TestCase):
         # The filename of the example preferences file.
         self.example = resource_filename(PKG, 'example.ini')
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
-
-        return
 
     ###########################################################################
     # Tests.
@@ -118,8 +114,6 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.assertEqual('0.75', p.get('acme.ui.ratio'))
         self.assertEqual(0.75, acme_ui.ratio)
 
-        return
-
     def test_default_values(self):
         """ instance scope preferences path """
 
@@ -147,8 +141,6 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.assertEqual(50, acme_ui.width)
         self.assertEqual(1.0, acme_ui.ratio)
         self.assertTrue(acme_ui.visible)
-
-        return
 
     def test_load_and_save(self):
         """ load and save """
@@ -213,8 +205,6 @@ class PreferenceBindingTestCase(unittest.TestCase):
         os.remove(tmp)
         os.rmdir(tmpdir)
 
-        return
-
     def test_explicit_preferences(self):
         """ explicit preferences """
 
@@ -248,8 +238,6 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.assertEqual(50, acme_ui.width)
         self.assertEqual(0.0, acme_ui.ratio)
         self.assertTrue(acme_ui.visible)
-
-        return
 
     def test_nested_set_in_trait_change_handler(self):
         """ nested set in trait change handler """
@@ -298,8 +286,6 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.assertEqual(3.0, acme_ui.ratio)
         self.assertEqual('3.0', p.get('acme.ui.ratio'))
 
-        return
-
     def test_trait_name_different_to_preference_name(self):
 
         p = self.preferences
@@ -326,5 +312,3 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.assertEqual('color', listener.trait_name)
         self.assertEqual('blue', listener.old)
         self.assertEqual('red', listener.new)
-
-        return

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -42,8 +42,6 @@ class PreferencesTestCase(unittest.TestCase):
         # Remove the temporary directory.
         os.rmdir(self.tmpdir)
 
-        return
-
     ###########################################################################
     # Tests.
     ###########################################################################
@@ -57,8 +55,6 @@ class PreferencesTestCase(unittest.TestCase):
         set_default_preferences(self.preferences)
         self.assertEqual(self.preferences, get_default_preferences())
 
-        return
-
     def test_get_and_set_str(self):
         """ get and set str """
 
@@ -67,8 +63,6 @@ class PreferencesTestCase(unittest.TestCase):
         # Set a string preference.
         p.set('acme.ui.bgcolor', 'blue')
         self.assertEqual('blue', p.get('acme.ui.bgcolor'))
-
-        return
 
     def test_get_and_set_int(self):
         """ get and set int """
@@ -80,8 +74,6 @@ class PreferencesTestCase(unittest.TestCase):
         p.set('acme.ui.width', 50)
         self.assertEqual('50', p.get('acme.ui.width'))
 
-        return
-
     def test_get_and_set_float(self):
         """ get and set float """
 
@@ -91,8 +83,6 @@ class PreferencesTestCase(unittest.TestCase):
         # manager *always* returns preference values as strings.
         p.set('acme.ui.ratio', 1.0)
         self.assertEqual('1.0', p.get('acme.ui.ratio'))
-
-        return
 
     def test_get_and_set_bool(self):
         """ get and set bool """
@@ -104,8 +94,6 @@ class PreferencesTestCase(unittest.TestCase):
         p.set('acme.ui.visible', True)
         self.assertEqual('True', p.get('acme.ui.visible'))
 
-        return
-
     def test_get_and_set_list_of_str(self):
         """ get and set list of str """
 
@@ -115,8 +103,6 @@ class PreferencesTestCase(unittest.TestCase):
         # manager *always* returns preference values as strings.
         p.set('acme.ui.names', ['fred', 'wilma', 'barney'])
         self.assertEqual("['fred', 'wilma', 'barney']", p.get('acme.ui.names'))
-
-        return
 
     def test_get_and_set_list_of_int(self):
         """ get and set list of int """
@@ -128,8 +114,6 @@ class PreferencesTestCase(unittest.TestCase):
         p.set('acme.ui.offsets', [1, 2, 3])
         self.assertEqual('[1, 2, 3]', p.get('acme.ui.offsets'))
 
-        return
-
     def test_empty_path(self):
         """ empty path """
 
@@ -138,8 +122,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertRaises(ValueError, p.get, '')
         self.assertRaises(ValueError, p.remove, '')
         self.assertRaises(ValueError, p.set, '', 'a value')
-
-        return
 
     def test_default_values(self):
         """ default values """
@@ -155,8 +137,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual('a value', p.get('bogus', 'a value'))
         self.assertEqual('a value', p.get('acme.bogus', 'a value'))
         self.assertEqual('a value', p.get('acme.ui.bogus', 'a value'))
-
-        return
 
     def test_keys(self):
         """ keys """
@@ -198,8 +178,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual([], p.keys('bogus.blargle'))
         self.assertEqual([], p.keys('bogus.blargle.foogle'))
 
-        return
-
     def test_node(self):
         """ node """
 
@@ -232,8 +210,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual('acme.ui.splash_screen', node.path)
         self.assertEqual(p.node('acme.ui'), node.parent)
 
-        return
-
     def test_node_exists(self):
         """ node exists """
 
@@ -244,8 +220,6 @@ class PreferencesTestCase(unittest.TestCase):
 
         p.node('acme')
         self.assertTrue(p.node_exists('acme'))
-
-        return
 
     def test_node_names(self):
         """ node names """
@@ -287,8 +261,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual([], p.node_names('bogus.blargle'))
         self.assertEqual([], p.node_names('bogus.blargle.foogle'))
 
-        return
-
     def test_clear(self):
         """ clear """
 
@@ -306,8 +278,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertIsNone(p.get('acme.ui.width'))
         self.assertEqual(0, len(p.keys('acme.ui')))
 
-        return
-
     def test_remove(self):
         """ remove """
 
@@ -324,8 +294,6 @@ class PreferencesTestCase(unittest.TestCase):
         # Make sure we can't remove nodes!
         p.remove('acme.ui')
         self.assertTrue(p.node_exists('acme.ui'))
-
-        return
 
     def test_flush(self):
         """ flush """
@@ -365,8 +333,6 @@ class PreferencesTestCase(unittest.TestCase):
             # Clean up!
             os.remove(tmp)
 
-        return
-
     def test_load(self):
         """ load """
 
@@ -385,8 +351,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual("['joe', 'fred', 'jane']", p.get('acme.ui.names'))
         self.assertEqual('splash', p.get('acme.ui.splash_screen.image'))
         self.assertEqual('red', p.get('acme.ui.splash_screen.fgcolor'))
-
-        return
 
     def test_load_with_filename_trait_set(self):
         """ load with filename trait set """
@@ -423,8 +387,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual("['joe', 'fred', 'jane']", p.get('acme.ui.names'))
         self.assertEqual('splash', p.get('acme.ui.splash_screen.image'))
         self.assertEqual('red', p.get('acme.ui.splash_screen.fgcolor'))
-
-        return
 
     def test_save(self):
         """ save """
@@ -472,8 +434,6 @@ class PreferencesTestCase(unittest.TestCase):
             # Clean up!
             os.remove(tmp)
 
-        return
-
     def SKIPtest_dump(self):
         """ dump """
 
@@ -485,8 +445,6 @@ class PreferencesTestCase(unittest.TestCase):
         # Load the preferences from an 'ini' file.
         p.load(self.example)
         p.dump()
-
-        return
 
     def test_get_inherited(self):
         """ get inherited """
@@ -512,8 +470,6 @@ class PreferencesTestCase(unittest.TestCase):
         p.remove('bgcolor')
         self.assertEqual(None, p.get('acme.ui.bgcolor', inherit=True))
 
-        return
-
     def test_add_listener(self):
         """ add listener """
 
@@ -526,8 +482,6 @@ class PreferencesTestCase(unittest.TestCase):
             listener.key  = key
             listener.old  = old
             listener.new  = new
-
-            return
 
         # Add a listener.
         p.add_preferences_listener(listener, 'acme.ui')
@@ -547,8 +501,6 @@ class PreferencesTestCase(unittest.TestCase):
         self.assertEqual('blue', listener.old)
         self.assertEqual('red', listener.new)
 
-        return
-
     def test_remove_listener(self):
         """ remove listener """
 
@@ -561,8 +513,6 @@ class PreferencesTestCase(unittest.TestCase):
             listener.key  = key
             listener.old  = old
             listener.new  = new
-
-            return
 
         # Add a listener.
         p.add_preferences_listener(listener, 'acme.ui')
@@ -583,8 +533,6 @@ class PreferencesTestCase(unittest.TestCase):
         p.set('acme.ui.bgcolor', 'blue')
         self.assertIsNone(listener.node)
 
-        return
-
     def test_set_with_same_value(self):
         """ set with same value """
 
@@ -597,8 +545,6 @@ class PreferencesTestCase(unittest.TestCase):
             listener.key  = key
             listener.old  = old
             listener.new  = new
-
-            return
 
         # Add a listener.
         p.add_preferences_listener(listener, 'acme.ui')
@@ -616,5 +562,3 @@ class PreferencesTestCase(unittest.TestCase):
         # Set the same value and make sure the listener *doesn't* get called.
         p.set('acme.ui.bgcolor', 'blue')
         self.assertIsNone(listener.node)
-
-        return

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -59,15 +59,11 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # A temporary directory that can safely be written to.
         self.tmpdir = tempfile.mkdtemp()
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
 
         # Remove the temporary directory.
         shutil.rmtree(self.tmpdir)
-
-        return
 
     ###########################################################################
     # Tests.
@@ -128,8 +124,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', bgcolor_listener.old)
         self.assertEqual('red', bgcolor_listener.new)
 
-        return
-
     def test_instance_scope_preferences_path(self):
         """ instance scope preferences path """
 
@@ -182,8 +176,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', bgcolor_listener.old)
         self.assertEqual('red', bgcolor_listener.new)
 
-        return
-
     def test_default_values(self):
         """ default values """
 
@@ -214,8 +206,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual(u'description', helper.description)
         self.assertEqual([1, 2, 3, 4], helper.offsets)
         self.assertEqual(['joe', 'fred', 'jane'], helper.names)
-
-        return
 
     def test_real_unicode_values(self):
         """ Test with real life unicode values """
@@ -264,8 +254,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual(second_unicode_str, p.get('acme.ui.description'))
         self.assertEqual(u'True', p.get('acme.ui.visible'))
         self.assertTrue(helper.visible)
-        
-        return
 
     def test_no_preferences_path(self):
         """ no preferences path """
@@ -287,8 +275,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
 
         # Cannot create a helper with a preferences path.
         self.assertRaises(SystemError, AcmeUIPreferencesHelper)
-
-        return
 
     def test_sync_trait(self):
         """ sync trait """
@@ -359,8 +345,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('yellow', bgcolor_listener.old)
         self.assertEqual('red', bgcolor_listener.new)
 
-        return
-
     def test_scoped_preferences(self):
         """ scoped preferences """
 
@@ -389,8 +373,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # And that the non-existent trait gets the default value.
         self.assertEqual('', helper.name)
 
-        return
-
     def test_preference_not_in_file(self):
         """ preference not in file """
 
@@ -414,8 +396,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # Make sure the trait is set!
         self.assertEqual('Acme Plus', helper.title)
         self.assertEqual('Acme Plus', self.preferences.get('acme.ui.title'))
-
-        return
 
     def test_preferences_node_changed(self):
         """ preferences node changed """
@@ -484,8 +464,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual('red', bgcolor_listener.old)
         self.assertEqual('black', bgcolor_listener.new)
 
-        return
-
     def test_nested_set_in_trait_change_handler(self):
         """ nested set in trait change handler """
 
@@ -533,8 +511,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.assertEqual(3.0, helper.ratio)
         self.assertEqual('3.0', p.get('acme.ui.ratio'))
 
-        return
-
     # fixme: No comments - nice work... I added the doc string and the 'return'
     # to be compatible with the rest of the module. Interns please note correct
     # procedure when modifying existing code. If in doubt, ask a developer.
@@ -550,5 +526,3 @@ class PreferencesHelperTestCase(unittest.TestCase):
         helper = AcmeUIPreferencesHelper(preferences_path='acme.ui')
 
         self.assertEqual('50', helper.width)
-
-        return

--- a/apptools/preferences/tests/test_py_config_file.py
+++ b/apptools/preferences/tests/test_py_config_file.py
@@ -30,12 +30,8 @@ class PyConfigFileTestCase(unittest.TestCase):
         self.example = resource_filename(PKG, 'py_config_example.ini')
         self.example_2 = resource_filename(PKG, 'py_config_example_2.ini')
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
-
-        return
 
     ###########################################################################
     # Tests.
@@ -58,8 +54,6 @@ class PyConfigFileTestCase(unittest.TestCase):
         self.assertEqual(90, config['tds.foogle']['joe'])
         self.assertEqual("meerkat", config['simples']['animal'])
 
-        return
-
     def test_load_from_file(self):
         """ load from file """
 
@@ -76,8 +70,6 @@ class PyConfigFileTestCase(unittest.TestCase):
         self.assertEqual(100, config['acme.ui.other']['wilma'])
         self.assertEqual(90, config['tds.foogle']['joe'])
         self.assertEqual("meerkat", config['simples']['animal'])
-
-        return
 
     def test_save(self):
         """ save """
@@ -124,8 +116,6 @@ class PyConfigFileTestCase(unittest.TestCase):
             os.remove(tmp)
             os.rmdir(tmpdir)
 
-        return
-
     def test_load_multiple_files(self):
         """ load multiple files """
 
@@ -167,5 +157,3 @@ class PyConfigFileTestCase(unittest.TestCase):
 
         # ... and that the new ones can refer to the old ones!
         self.assertEqual(180, config['acme.ui']['blimey'])
-
-        return

--- a/apptools/preferences/tests/test_scoped_preferences.py
+++ b/apptools/preferences/tests/test_scoped_preferences.py
@@ -37,15 +37,11 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # A temporary directory that can safely be written to.
         self.tmpdir = tempfile.mkdtemp()
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
 
         # Remove the temporary directory.
         os.rmdir(self.tmpdir)
-
-        return
 
     ###########################################################################
     # Tests overridden from 'PreferencesTestCase'.
@@ -83,8 +79,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.assertEqual('acme.ui.splash_screen', node.path)
         self.assertEqual(p.node('application/acme.ui'), node.parent)
 
-        return
-
     def test_save(self):
         """ save """
 
@@ -115,8 +109,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # Cleanup.
         os.remove(tmp)
 
-        return
-
     ###########################################################################
     # Tests.
     ###########################################################################
@@ -139,8 +131,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # Look it up specifically in the primary scope.
         self.assertEqual('bar', preferences.get('b/acme.foo'))
 
-        return
-
     def test_builtin_scopes(self):
         """ builtin scopes """
 
@@ -150,8 +140,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.assertTrue(p.node_exists('application/'))
         self.assertTrue(p.node_exists('default/'))
 
-        return
-
     def test_get_and_set_in_specific_scope(self):
         """ get and set in specific scope """
 
@@ -160,8 +148,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # Set a preference and make sure we can get it again!
         p.set('default/acme.ui.bgcolor', 'red')
         self.assertEqual('red', p.get('default/acme.ui.bgcolor'))
-
-        return
 
     def test_clear_in_specific_scope(self):
         """ clear in specific scope """
@@ -183,8 +169,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # We should now get the value from the default scope.
         self.assertEqual('yellow', p.get('acme.ui.bgcolor'))
 
-        return
-
     def test_remove_in_specific_scope(self):
         """ remove in specific scope """
 
@@ -203,8 +187,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
 
         # We should now get the value from the default scope.
         self.assertEqual('yellow', p.get('acme.ui.bgcolor'))
-
-        return
 
     def test_keys_in_specific_scope(self):
         """ keys in specific scope """
@@ -244,8 +226,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
 
         self.assertEqual(['a', 'b', 'c'], keys)
 
-        return
-
     def test_node_in_specific_scope(self):
         """ node in specific scope """
 
@@ -278,8 +258,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.assertEqual('acme.ui.splash_screen', node.path)
         self.assertEqual(p.node('default/acme.ui'), node.parent)
 
-        return
-
     def test_node_exists_in_specific_scope(self):
         """ node exists """
 
@@ -290,8 +268,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
 
         p.node('default/acme')
         self.assertTrue(p.node_exists('default/acme'))
-
-        return
 
     def test_node_names_in_specific_scope(self):
         """ node names in specific scope """
@@ -331,8 +307,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
 
         self.assertEqual(['a', 'b', 'c'], names)
 
-        return
-
     def test_default_lookup_order(self):
         """ default lookup order """
 
@@ -349,8 +323,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         # But we can still get at each scope individually.
         self.assertEqual('red', p.get('application/acme.ui.bgcolor'))
         self.assertEqual('yellow', p.get('default/acme.ui.bgcolor'))
-
-        return
 
     def test_lookup_order(self):
         """ lookup order """
@@ -370,8 +342,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.assertEqual('red', p.get('application/acme.ui.bgcolor'))
         self.assertEqual('yellow', p.get('default/acme.ui.bgcolor'))
 
-        return
-
     def test_add_listener_in_specific_scope(self):
         """ add listener in specific scope. """
 
@@ -384,8 +354,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
             listener.key  = key
             listener.old  = old
             listener.new  = new
-
-            return
 
         # Add a listener.
         p.add_preferences_listener(listener, 'default/acme.ui')
@@ -405,8 +373,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.assertEqual('blue', listener.old)
         self.assertEqual('red', listener.new)
 
-        return
-
     def test_remove_listener_in_specific_scope(self):
         """ remove listener in specific scope. """
 
@@ -419,8 +385,6 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
             listener.key  = key
             listener.old  = old
             listener.new  = new
-
-            return
 
         # Add a listener.
         p.add_preferences_listener(listener, 'default/acme.ui')
@@ -441,13 +405,9 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         p.set('default/acme.ui.bgcolor', 'blue')
         self.assertIsNone(listener.node)
 
-        return
-
     def test_non_existent_scope(self):
         """ non existent scope """
 
         p = self.preferences
 
         self.assertRaises(ValueError, p.get, 'bogus/acme.ui.bgcolor')
-
-        return


### PR DESCRIPTION
Bare returns at the end of a function is unnecessary. This PR removes the ones in `apptools.preferences.tests`.

This is a localized effort, so that when we try to add tests in the package, we don't have to be forced to add those returns because that's the consistent thing to do in the local context.
**Checklist**
- Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst): Not news worthy
