### PR TITLE
Explicitly requires Python >= 3.6

### DIFF
--- a/docs/releases/upcoming/190.removal.rst
+++ b/docs/releases/upcoming/190.removal.rst
@@ -1,0 +1,1 @@
+Remove support for Python 2.7 and 3.5 (#190)

--- a/etstool.py
+++ b/etstool.py
@@ -53,7 +53,7 @@ you can run tests in all supported runtimes::
 
     python etstool.py test_all
 
-Currently supported runtime values are ``2.7``, ``3.5``, ``3.6``.  Not all
+Currently supported runtime value is``3.6``.  Not all
 runtimes will work, but the tasks will fail with a clear error if that is the
 case.
 
@@ -95,8 +95,6 @@ import click
 DEFAULT_RUNTIME = "3.6"
 
 supported_runtimes = [
-    '2.7',
-    '3.5',
     '3.6',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -138,4 +138,5 @@ if __name__ == "__main__":
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
-          )
+          python_requires=">=3.6",
+    )


### PR DESCRIPTION
This PR updates `setup.py` and `etstool.py` to remove support for Python 2.7 and Python 3.5.

The changes on `setup.py` will be useful for package managers downstream that are automatically building open-source packages (I wish Python 2.7 was gone from the world but there exists systems that still requires it.)

Related to #120

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst) <--- Yes, this is news worthy.
