### PR TITLE
remove dead code

### DIFF
--- a/apptools/logger/agent/quality_agent_mailer.py
+++ b/apptools/logger/agent/quality_agent_mailer.py
@@ -102,18 +102,6 @@ def create_email_message(fromaddr, toaddrs, ccaddrs, subject, priority,
         except:
             logger.exception('Failed to include environment variables with message')
 
-
-# FIXME: no project plugins exist for Envisage 3, yet, and this isn't the right
-# way to do it, either. See the docstring of attachments.py.
-#    # Attach the project if requested ...
-#    if include_project:
-#        from attachments import Attachments
-#        try:
-#            attachments = Attachments(message)
-#            attachments.package_any_relevant_files()
-#        except:
-#            logger.exception('Failed to include workspace files with message')
-
     return message
 
 

--- a/apptools/naming/py_context.py
+++ b/apptools/naming/py_context.py
@@ -117,13 +117,6 @@ class PyContext(Context, Referenceable):
         state = naming_manager.get_state_to_bind(obj, name,self)
         self.namespace[name] = state
 
-        # Trait event notification.
-        # An "added" event is fired by the bind method of the base calss (which calls
-        # this one), so we don't need to do the changed here (which would be the wrong
-        # thing anyway) -- LGV
-        #
-        # self.trait_property_changed('context_changed', None, None)
-
         return
 
     def _rebind(self, name, obj):

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -303,11 +303,6 @@ class PyFSContext(DirContext, Referenceable):
     def _rebind(self, name, obj):
         """ Rebinds a name to an object in this context. """
 
-        # We unbind first to make sure that the old file gets removed (this
-        # is handy if the object that we are rebinding has a different
-        # serializer than the current one).
-        #self._unbind(name)
-
         self._bind(name, obj)
 
         return

--- a/apptools/persistence/spickle.py
+++ b/apptools/persistence/spickle.py
@@ -136,10 +136,6 @@ class StatePickler(Pickler):
                 raise PicklingError(
                     "args from reduce() should be a tuple")
 
-        # Assert that func is callable
-        #if not callable(func):
-        #    raise PicklingError("func from reduce should be callable")
-
         save = self.save
         write = self.write
 

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -134,9 +134,7 @@ class VersionedUnpickler(NewUnpickler):
             # check to see if this class needs to be mapped to a new class
             # or module name
             original_module, original_name  = module, name
-            #logger.debug('omodule:%s oname:%s' % (original_module, original_name))
             module, name = self.updater.get_latest(module, name)
-            #logger.debug('module:%s name:%s' % (module, name))
 
             # load the class...
             '''__import__(module)
@@ -186,7 +184,6 @@ class VersionedUnpickler(NewUnpickler):
 
         else:
             pass
-            #print('No updater fn to worry about')
 
         return
 
@@ -228,6 +225,5 @@ class VersionedUnpickler(NewUnpickler):
         objects that are required for v1 and v2 do not have to exist they only
         need to be placeholders for the state during an upgrade.
         """
-        #print("importing %s %s" % (name, module))
         module = __import__(module, globals(), locals(), [name])
         return vars(module)[name]

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -137,9 +137,6 @@ class VersionedUnpickler(NewUnpickler):
             module, name = self.updater.get_latest(module, name)
 
             # load the class...
-            '''__import__(module)
-            mod = sys.modules[module]
-            klass = getattr(mod, name)'''
             klass = self.import_name(module, name)
 
             # add the updater....  TODO - why the old name?
@@ -201,7 +198,6 @@ class VersionedUnpickler(NewUnpickler):
                 # and run later when we have finished updating the class
                 name = '__setstate_original__'
 
-            #logger.debug('renaming __setstate__ to %s' % name)
             method = getattr(klass, '__setstate__')
             m = _unbound_method(method, klass)
             setattr(klass, name, m)

--- a/apptools/preferences/ui/i_preferences_page.py
+++ b/apptools/preferences/ui/i_preferences_page.py
@@ -21,3 +21,4 @@ class IPreferencesPage(Interface):
 
     def apply(self):
         """ Apply the page's preferences. """
+        pass

--- a/apptools/preferences/ui/i_preferences_page.py
+++ b/apptools/preferences/ui/i_preferences_page.py
@@ -21,12 +21,3 @@ class IPreferencesPage(Interface):
 
     def apply(self):
         """ Apply the page's preferences. """
-
-    # fixme: We would like to be able to have the following API so that
-    # developers are not forced into using traits UI for their preferences
-    # pages, but at the moment I can't work out how to do it!
-##     def create_control(self, parent):
-##         """ Create the toolkit-specific control that represents the page. """
-
-##     def destroy_control(self, parent):
-##         """ Destroy the toolkit-specific control that represents the page. """

--- a/apptools/preferences/ui/preferences_manager.py
+++ b/apptools/preferences/ui/preferences_manager.py
@@ -12,10 +12,6 @@ from traitsui.menu import Action
 from .preferences_node import PreferencesNode
 from .preferences_page import PreferencesPage
 
-# fixme: This is part of the attempt to allow developers to use non-Traits UI
-# preferences pages. It doesn't work yet!
-##from widget_editor import WidgetEditor
-
 
 # A tree editor for preferences nodes.
 tree_editor = TreeEditor(

--- a/apptools/preferences/ui/preferences_page.py
+++ b/apptools/preferences/ui/preferences_page.py
@@ -59,26 +59,6 @@ class PreferencesPage(PreferencesHelper):
 
         return
 
-    # fixme: We would like to be able to have the following API so that
-    # developers are not forced into using traits UI for their preferences
-    # pages, but at the moment I can't work out how to do it!
-##     def create_control(self, parent):
-##         """ Create the toolkit-specific control that represents the page. """
-
-##         if self._ui is None:
-##             self._ui = self.edit_traits(parent=parent, kind='subpanel')
-
-##         return self._ui.control
-
-##     def destroy_control(self):
-##         """ Destroy the toolkit-specific control that represents the page. """
-
-##         if self._ui is not None:
-##             self._ui.dispose()
-##             self._ui = None
-
-##         return
-
     ###########################################################################
     # Private interface.
     ###########################################################################

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -159,8 +159,6 @@ class TestRecorder(unittest.TestCase):
         toy.type = 'rat'
         self.assertEqual(tape.lines[-1], "child.toy.type = 'teddy'")
 
-        #print(tape.script)
-
         # Stop recording.
         n = len(tape.lines)
         tape.unregister(p)

--- a/integrationtests/persistence/test_persistence.py
+++ b/integrationtests/persistence/test_persistence.py
@@ -41,7 +41,6 @@ def save(fname, str):
 if __name__ == '__main__':
 
     # Create dummy test data .......
-    #from cStringIO import StringIO
     import pickle
 
     obj = Foo0()
@@ -80,4 +79,3 @@ if __name__ == '__main__':
     p = VersionedUnpickler(f, updater).load()
     print(p)
     print('Restored version %s %s' % (p.lastname, p.firstname))
-    #print(p.set)


### PR DESCRIPTION
Throughout the `apptools` code base there was a lot of commented out code.  Some of it is print statements or no longer used import statements.  Others are things like "we want to be able do this: (bunch of code)  but it doesn't work right now.  These things should be github issues and not clouding the code base.  If a reviewer finds anything deleted here to be important, it can be added back, or preferably have a github issue opened.  Other cases seem like they were part of a PR review process in the form of # actually we dont need this # some code.  These have been removed as well. 

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
