### PR TITLE
Remove all checks for python version < 3 as we are dropping python2

### DIFF
--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -129,7 +129,7 @@ def gunzip_string(data):
     """Given a gzipped string (`data`) this unzips the string and
     returns it.
     """
-    if (bytes is not str and type(data) is bytes):
+    if type(data) is bytes:
         s = BytesIO(data)
     else:
         s = StringIO(data)

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -111,7 +111,6 @@ import numpy
 from . import version_registry
 from .file_path import FilePath
 
-PY_VER = sys.version_info[0]
 NumpyArrayType = type(numpy.array([]))
 
 
@@ -130,7 +129,7 @@ def gunzip_string(data):
     """Given a gzipped string (`data`) this unzips the string and
     returns it.
     """
-    if PY_VER== 2 or (bytes is not str and type(data) is bytes):
+    if (bytes is not str and type(data) is bytes):
         s = BytesIO(data)
     else:
         s = StringIO(data)
@@ -442,10 +441,7 @@ class StatePickler:
 
     def _do_numeric(self, value):
         idx = self._register(value)
-        if PY_VER > 2:
-            data = base64.encodebytes(gzip_string(numpy.ndarray.dumps(value)))
-        else:
-            data = base64.encodestring(gzip_string(numpy.ndarray.dumps(value)))
+        data = base64.encodebytes(gzip_string(numpy.ndarray.dumps(value)))
         return dict(type='numeric', id=idx, data=data)
 
 
@@ -650,15 +646,11 @@ class StateUnpickler:
         return result
 
     def _do_numeric(self, value, path):
-        if PY_VER > 2:
-            data = value['data']
-            if isinstance(data, str):
-                data = value['data'].encode('utf-8')
-            junk = gunzip_string(base64.decodebytes(data))
-            result = pickle.loads(junk, encoding='bytes')
-        else:
-            junk = gunzip_string(value['data'].decode('base64'))
-            result = pickle.loads(junk)
+        data = value['data']
+        if isinstance(data, str):
+            data = value['data'].encode('utf-8')
+        junk = gunzip_string(base64.decodebytes(data))
+        result = pickle.loads(junk, encoding='bytes')
         self._numeric[value['id']] = (path, result)
         self._obj_cache[value['id']] = result
         return result

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -6,7 +6,6 @@
 # License: BSD Style.
 
 # Standard library imports.
-import sys
 from imp import reload
 import unittest
 
@@ -43,10 +42,7 @@ class Handler:
 class TestVersionRegistry(unittest.TestCase):
     def test_get_version(self):
         """Test the get_version function."""
-        if sys.version_info[0] > 2:
-            extra = [(('object', 'builtins'), -1)]
-        else:
-            extra = []
+        extra = [(('object', 'builtins'), -1)]
         c = Classic()
         v = version_registry.get_version(c)
         res = extra + [(('Classic', __name__), 0)]


### PR DESCRIPTION
related to #120 

Since #190 has been merged and we intend to drop python 2 I believe it is fine to remove these checks now.  The changes in this PR all occur in the `persistence` sub package which right now, AFAIK, we plan on keeping.

Additionally see here: 
https://github.com/enthought/apptools/blob/a693c79e8547ccaafcf89f230c0b17edbc780655/apptools/persistence/spickle.py#L19-L20

I left this for now as there is already a relevant issue open: #57 

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
