### PR TITLE
Setup flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
       edm run -- python etstool.py install --runtime=${RUNTIME} || exit;
     fi
 script:
+  - edm run -- python etstool.py flake8 --runtime=${RUNTIME} || exit
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
 notifications:
   email:

--- a/etstool.py
+++ b/etstool.py
@@ -99,6 +99,7 @@ supported_runtimes = [
 ]
 
 dependencies = {
+    "flake8",
     "traitsui",
     "configobj",
     "coverage",
@@ -252,6 +253,25 @@ def cleanup(runtime, environment):
     click.echo("Cleaning up environment '{environment}'".format(**parameters))
     execute(commands, parameters)
     click.echo('Done cleanup')
+
+
+@cli.command()
+@click.option('--runtime', default=DEFAULT_RUNTIME)
+@click.option('--environment', default=None)
+def flake8(runtime, environment):
+    """ Run a flake8 check in a given environment.
+
+    """
+    parameters = get_parameters(runtime, environment)
+    targets = [
+        "apptools",
+        "examples",
+        "integrationtests",
+    ]
+    commands = [
+        "edm run -e {environment} -- python -m flake8 " + " ".join(targets)
+    ]
+    execute(commands, parameters)
 
 
 @cli.command(name='test-clean')

--- a/etstool.py
+++ b/etstool.py
@@ -265,6 +265,8 @@ def flake8(runtime, environment):
     parameters = get_parameters(runtime, environment)
     targets = [
         "apptools",
+        "etstool.py",
+        "setup.py",
         "examples",
         "integrationtests",
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[flake8]
+ignore = E266, W503
+exclude =
+    # The following list should eventually be empty.
+    apptools/_testing/*
+    apptools/help/*
+    apptools/io/*
+    apptools/logger/*
+    apptools/naming/*
+    apptools/persistence/*
+    apptools/preferences/*
+    apptools/scripting/*
+    apptools/selection/*
+    apptools/sweet_pickle/*
+    apptools/type_manager/*
+    apptools/type_registry/*
+    apptools/undo/*
+    examples/*
+    integrationtests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,7 @@ exclude =
     apptools/type_manager/*
     apptools/type_registry/*
     apptools/undo/*
+    etstool.py
     examples/*
+    setup.py
     integrationtests/*


### PR DESCRIPTION
This PR sets up flake8 for the codebase. A new `flake8` command is added to `etstool.py` but all of `apptools` is excluded when running `flake8`. The idea is to slowly get the codebase flake8-clean. Note that `examples`, `integrationtests` and `etstool.py`, `setup.py` are also flake8 targets.

contributes towards #145 

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ This has no effect on end users so no news fragment is added for this PR.