### PR TITLE
Update flake8 ignores

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -265,6 +265,7 @@ def flake8(runtime, environment):
     parameters = get_parameters(runtime, environment)
     targets = [
         "apptools",
+        "docs",
         "etstool.py",
         "setup.py",
         "examples",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 ignore = E266, W503
+per-file-ignores = */api.py:F401
 exclude =
     # The following list should eventually be empty.
     apptools/_testing/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ exclude =
     apptools/type_manager/*
     apptools/type_registry/*
     apptools/undo/*
+    docs/source/conf.py
     etstool.py
     examples/*
     setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ ignore = E266, W503
 per-file-ignores = */api.py:F401
 exclude =
     # The following list should eventually be empty.
-    apptools/_testing/*
     apptools/help/*
     apptools/io/*
     apptools/logger/*


### PR DESCRIPTION
Drive-by updates to the flake8 settings.

- `apptools/_testing` is already flake8-clean on master.
- `docs/source/conf.py` should be flaked too? (I can revert that)
- We expect unused imports in `*/api.py` files, skip all of them (so we don't have to laboriously skip F401 at every single line). 

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Not news worthy
