### PR TITLE
Replace pkg_resources with importlib_resources

### DIFF
--- a/apptools/persistence/tests/test_file_path.py
+++ b/apptools/persistence/tests/test_file_path.py
@@ -13,7 +13,7 @@ from os.path import abspath, dirname, basename, join
 from io import BytesIO
 
 # 3rd party imports.
-import pkg_resources
+from importlib_resources import files
 
 # Enthought library imports.
 from apptools.persistence import state_pickler
@@ -29,7 +29,7 @@ class TestFilePath(unittest.TestCase):
     def setUp(self):
         # If the cwd is somewhere under /tmp, that confuses the tests below.
         # Use the directory containing this file, instead.
-        test_cwd = pkg_resources.resource_filename("apptools.persistence", "")
+        test_cwd = os.fspath(files("apptools.persistence") / "")
         self.old_cwd = os.getcwd()
         os.chdir(test_cwd)
 

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -6,7 +6,7 @@ import os, tempfile, unittest
 from os.path import join
 
 # Major package imports.
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences, PreferenceBinding
@@ -43,7 +43,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
         self.preferences = set_default_preferences(Preferences())
 
         # The filename of the example preferences file.
-        self.example = resource_filename(PKG, "example.ini")
+        self.example = os.fspath(files(PKG) / "example.ini")
 
     def tearDown(self):
         """ Called immediately after each test method has been called. """

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -6,7 +6,7 @@ import os, tempfile, unittest
 from os.path import join
 
 # Major package imports.
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences
@@ -30,7 +30,7 @@ class PreferencesTestCase(unittest.TestCase):
         self.preferences = Preferences()
 
         # The filename of the example preferences file.
-        self.example = resource_filename(PKG, "example.ini")
+        self.example = os.fspath(files(PKG) / "example.ini")
 
         # A temporary directory that can safely be written to.
         self.tmpdir = tempfile.mkdtemp()

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -9,7 +9,7 @@ import time
 import unittest
 
 # Major package imports.
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences, PreferencesHelper
@@ -55,7 +55,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
         self.preferences = set_default_preferences(Preferences())
 
         # The filename of the example preferences file.
-        self.example = resource_filename(PKG, "example.ini")
+        self.example = os.fspath(files(PKG) / "example.ini")
 
         # A temporary directory that can safely be written to.
         self.tmpdir = tempfile.mkdtemp()

--- a/apptools/preferences/tests/test_py_config_file.py
+++ b/apptools/preferences/tests/test_py_config_file.py
@@ -6,7 +6,7 @@ import os, tempfile, unittest
 from os.path import join
 
 # Major package imports.
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 # Enthought library imports.
 from .py_config_file import PyConfigFile
@@ -27,8 +27,8 @@ class PyConfigFileTestCase(unittest.TestCase):
         """ Prepares the test fixture before each test method is called. """
 
         # The filenames of the example preferences files.
-        self.example = resource_filename(PKG, "py_config_example.ini")
-        self.example_2 = resource_filename(PKG, "py_config_example_2.ini")
+        self.example = os.fspath(files(PKG) / "py_config_example.ini")
+        self.example_2 = os.fspath(files(PKG) / "py_config_example_2.ini")
 
     def tearDown(self):
         """ Called immediately after each test method has been called. """

--- a/apptools/preferences/tests/test_scoped_preferences.py
+++ b/apptools/preferences/tests/test_scoped_preferences.py
@@ -6,7 +6,7 @@ import os, tempfile, unittest
 from os.path import join
 
 # Major package imports.
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences, ScopedPreferences
@@ -32,7 +32,7 @@ class ScopedPreferencesTestCase(PreferencesTestCase):
         self.preferences = ScopedPreferences()
 
         # The filename of the example preferences file.
-        self.example = resource_filename(PKG, "example.ini")
+        self.example = os.fspath(files(PKG) / "example.ini")
 
         # A temporary directory that can safely be written to.
         self.tmpdir = tempfile.mkdtemp()

--- a/etstool.py
+++ b/etstool.py
@@ -103,6 +103,7 @@ dependencies = {
     "traitsui",
     "configobj",
     "coverage",
+    "importlib_resources",
     "pytables",
     "pandas",
     "pyface",

--- a/etstool.py
+++ b/etstool.py
@@ -103,7 +103,7 @@ dependencies = {
     "traitsui",
     "configobj",
     "coverage",
-    "importlib_resources",
+    "importlib_resources>=1.1.0",
     "pytables",
     "pandas",
     "pyface",

--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,11 @@ if __name__ == "__main__":
               'six',
               'traitsui',
           ],
+          extras_require={
+              "test": [
+                  "importlib-resources>=1.1.0",
+              ],
+          },
           license='BSD',
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],


### PR DESCRIPTION
This PR replaces the use of `pkg_resources.resource_filename` with `importlib_resources.files`. Ref the migration guide for `importlib_resources` - https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ This has no effect on the end users so this does not warrant a news fragment.
