### PR TITLE
Fix Tests' AttributeError in Python 3.9 with base64.decodestring

### DIFF
--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -157,9 +157,8 @@ class TestDictPickler(unittest.TestCase):
         self._check_instance_and_references(obj, data)
 
         num_attr = "numeric" if data["numeric"]["type"] == "numeric" else "ref"
-        decodestring = getattr(base64, "decodebytes", base64.decodestring)
         junk = state_pickler.gunzip_string(
-            decodestring(data[num_attr]["data"])
+            base64.decodebytes(data[num_attr]["data"])
         )
         num = pickle.loads(junk)
         self.assertEqual(numpy.alltrue(numpy.ravel(num == obj.numeric)), 1)

--- a/docs/releases/upcoming/210.test.rst
+++ b/docs/releases/upcoming/210.test.rst
@@ -1,0 +1,1 @@
+Fix AttributeError on Python 3.9 due to usage of ``base64.decodestring`` in tests (#210)


### PR DESCRIPTION
Closes #209

`base64.decodestring` is deprecated in 3.1, and has been an alias of decodebytes

I searched the code base of apptools and it has only been used in tests. This PR fixes that particular tests.
Since we don't yet run against Python 3.9 on CI, I ran the test suite locally to verify it passes on Python 3.9 and OSX.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)

While this may not be news worthy for developers using apptools, this is perhaps news worthy for distribution packagers who run package test suites against their systems (that is, if they also have all the optional dependencies e.g. pytables, but that is an orthogonal issue.)
