### PR TITLE
Maint: Add test suite to the category of changes in Changelog

### DIFF
--- a/docs/releases/README.rst
+++ b/docs/releases/README.rst
@@ -12,7 +12,8 @@ Create a new file with a name like ``<pull-request>.<type>.rst``, where
 - ``bugfix``: Bug fixes
 - ``deprecation``: Deprecations of public API
 - ``removal``: Removal of public API
-- ``doc``: Documentation changes.
+- ``doc``: Documentation changes
+- ``test``: Changes to test suite ('end users' are distribution packagers)
 
 Then write a short sentence in the file that describes the changes for the
 end users, e.g. in ``123.removal.rst``::

--- a/etstool.py
+++ b/etstool.py
@@ -337,6 +337,7 @@ def changelog(ctx):
             "deprecation": "Deprecations",
             "removal": "Removals",
             "doc": "Documentation changes",
+            "test": "Test suite",
         }
     }
 


### PR DESCRIPTION
Motivated by #210, this PR proposes adding a category for news fragments.

Certain changes to test suites may be of interest to distribution packagers (e.g. the build team building EDM eggs, people building packages for Ubuntu, etc.). This PR adds a category for these kind of news fragments to be added and used while building the changelog.

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Not news worthy as this is internal changes for developers maintaining apptools.