### PR TITLE
Remove deprecated create_log_file_handler

### DIFF
--- a/apptools/logger/api.py
+++ b/apptools/logger/api.py
@@ -1,4 +1,4 @@
-from .logger import add_log_queue_handler, create_log_file_handler
+from .logger import add_log_queue_handler
 from .logger import FORMATTER, LEVEL, LogFileHandler
 from .log_point import log_point
 from .filtering_handler import FilteringHandler

--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -51,34 +51,6 @@ class LogFileHandler(RotatingFileHandler):
         self.setLevel(level)
 
 
-@deprecated('use "LogFileHandler"')
-def create_log_file_handler(
-    path, maxBytes=1000000, backupCount=3, level=None, formatter=None
-):
-    """Creates a log file handler.
-
-    This is just a convenience function to make it easy to create the same
-    kind of handlers across applications.
-
-    It sets the handler's formatter to the default formatter, and its logging
-    level to the default logging level.
-
-    """
-    if level is None:
-        level = LEVEL
-    if formatter is None:
-        formatter = FORMATTER
-
-    handler = RotatingFileHandler(
-        path, maxBytes=maxBytes, backupCount=backupCount
-    )
-
-    handler.setFormatter(formatter)
-    handler.setLevel(level)
-
-    return handler
-
-
 def add_log_queue_handler(logger, level=None, formatter=None):
     """Adds a queueing log handler to a logger."""
     if level is None:

--- a/docs/releases/upcoming/218.removal.rst
+++ b/docs/releases/upcoming/218.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated create_log_file_handler function (#218)


### PR DESCRIPTION
fixes #214 

This PR simply removes the deprecated `create_log_file_handler` function from `apptools.logger.logger` and removes its import from the api module.  

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
