### PR TITLE
Document apptools.naming

### DIFF
--- a/docs/releases/upcoming/221.doc.rst
+++ b/docs/releases/upcoming/221.doc.rst
@@ -1,0 +1,1 @@
+Add a brief section to documentation for ``apptools.naming`` (#221)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ AppTools Documentation
     scripting/*
     undo/*
     selection/*
+    naming/*
     api
 
 * :ref:`search`

--- a/docs/source/naming/Introduction.rst
+++ b/docs/source/naming/Introduction.rst
@@ -1,0 +1,6 @@
+Naming
+======
+
+Apptools naming is a python implementation of the naming portion of the `Java
+Naming and Directory Interface <https://docs.oracle.com/javase/tutorial/jndi/TOC.html>`_,
+including specific implementations for a heirarchy of Python objects.

--- a/docs/source/naming/Introduction.rst
+++ b/docs/source/naming/Introduction.rst
@@ -3,4 +3,5 @@ Naming
 
 Apptools naming is a python implementation of the naming portion of the `Java
 Naming and Directory Interface <https://docs.oracle.com/javase/tutorial/jndi/TOC.html>`_,
-including specific implementations for a heirarchy of Python objects.
+including specific implementations for a heirarchy of Python objects. You can
+also find the Java JNDI tutorial `here <https://docs.oracle.com/javase/jndi/tutorial/>`_.

--- a/docs/source/naming/Introduction.rst
+++ b/docs/source/naming/Introduction.rst
@@ -1,7 +1,7 @@
 Naming
 ======
 
-Apptools naming is a python implementation of the naming portion of the `Java
+:mod:`apptools.naming` package is a Python implementation of the Naming portion of the `Java
 Naming and Directory Interface <https://docs.oracle.com/javase/tutorial/jndi/TOC.html>`_,
 including specific implementations for a heirarchy of Python objects. You can
 also find the Java JNDI tutorial `here <https://docs.oracle.com/javase/jndi/tutorial/>`_.


### PR DESCRIPTION
Closes #139 (for now at least, we may want to bulk up the documentation at some point)

This PR adds a very small section to the apptools documentation for the `naming` subpackage.  All it says is that this is a python implementation of the Java Naming and Directory Interface, and provides a couple links to JDNI documentation. 

Note the two links are a little redundant (there is repeated information between them), but some things are different.  (I'm not exactly sure why both links exist, and the content isn't merged)

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
