### PR TITLE
Fix DeprecationWarning from importing imp

### DIFF
--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -6,7 +6,7 @@
 # License: BSD Style.
 
 # Standard library imports.
-from imp import reload
+from importlib import reload
 import unittest
 
 # Enthought library imports.


### PR DESCRIPTION
This is a simple fix to the deprecation warning seen in #208

Closes #208

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Not news worthy
