### PR TITLE
Fix use of _items as a normal trait in PreferencesHelper and PreferencesPage

### DIFF
--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -75,21 +75,20 @@ class PreferencesHelper(HasTraits):
         if self.preferences is None:
             return
 
+        # If we were the one that set the trait (because the underlying
+        # preferences node changed) then do nothing.
+        if self._is_preference_trait(trait_name):
+            self.preferences.set("%s.%s" % (self._get_path(), trait_name), new)
+
         # If the trait was a list or dict '_items' trait then just treat it as
         # if the entire list or dict was changed.
-        if trait_name.endswith('_items'):
+        elif trait_name.endswith('_items'):
             trait_name = trait_name[:-6]
             if self._is_preference_trait(trait_name):
                 self.preferences.set(
                     '%s.%s' % (self._get_path(), trait_name),
                     getattr(self, trait_name)
                 )
-                return
-
-        # If we were the one that set the trait (because the underlying
-        # preferences node changed) then do nothing.
-        if self._is_preference_trait(trait_name):
-            self.preferences.set("%s.%s" % (self._get_path(), trait_name), new)
 
         return
 
@@ -205,4 +204,4 @@ class PreferencesHelper(HasTraits):
         ):
             return False
 
-        return True
+        return trait_name in self.editable_traits()

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -75,8 +75,6 @@ class PreferencesHelper(HasTraits):
         if self.preferences is None:
             return
 
-        # If we were the one that set the trait (because the underlying
-        # preferences node changed) then do nothing.
         if self._is_preference_trait(trait_name):
             self.preferences.set("%s.%s" % (self._get_path(), trait_name), new)
 
@@ -89,6 +87,9 @@ class PreferencesHelper(HasTraits):
                     '%s.%s' % (self._get_path(), trait_name),
                     getattr(self, trait_name)
                 )
+
+        # If the change refers to a trait defined on this class, then
+        # the trait is not a preference trait and we do nothing.
 
         return
 

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -319,6 +319,32 @@ class PreferencesHelperTestCase(unittest.TestCase):
                 str(helper.list_of_list_of_str)
             )
 
+    def test_sync_anytrait_items_not_event(self):
+        """ Test sychronizing trait with name *_items which is a normal trait
+        rather than an event trait for listening to list/dict/set mutation.
+        """
+
+        class MyPreferencesHelper(PreferencesHelper):
+            preferences_path = Str('my_section')
+
+            names_items = Str()
+
+        helper = MyPreferencesHelper(preferences=self.preferences)
+        helper.names_items = "Hello"
+
+        self.preferences.save(self.tmpfile)
+        new_preferences = Preferences()
+        new_preferences.load(self.tmpfile)
+
+        self.assertEqual(
+            sorted(new_preferences.keys("my_section")),
+            ["names_items"]
+        )
+        self.assertEqual(
+            new_preferences.get("my_section.names_items"),
+            str(helper.names_items),
+        )
+
     def test_no_preferences_path(self):
         """ no preferences path """
 

--- a/apptools/preferences/ui/preferences_page.py
+++ b/apptools/preferences/ui/preferences_page.py
@@ -73,15 +73,14 @@ class PreferencesPage(PreferencesHelper):
 
         """
 
-        # If the trait was a list or dict '_items' trait then just treat it as
-        # if the entire list or dict was changed.
-        if trait_name.endswith("_items"):
+        if self._is_preference_trait(trait_name):
+            self._changed[trait_name] = new
+        elif trait_name.endswith("_items"):
+            # If the trait was a list or dict '_items' trait then just treat it
+            # as if the entire list or dict was changed.
             trait_name = trait_name[:-6]
             if self._is_preference_trait(trait_name):
                 self._changed[trait_name] = getattr(self, trait_name)
-
-        elif self._is_preference_trait(trait_name):
-            self._changed[trait_name] = new
 
         return
 
@@ -97,4 +96,4 @@ class PreferencesPage(PreferencesHelper):
         ):
             return False
 
-        return True
+        return trait_name in self.editable_traits()

--- a/docs/releases/upcoming/226.bugfix.rst
+++ b/docs/releases/upcoming/226.bugfix.rst
@@ -1,0 +1,1 @@
+Fix synchronizing preference trait with name *_items (#226)


### PR DESCRIPTION
Closes #225

This PR changes the listener for synchronizing the traits on the PreferencesHelper and PreferencesPage with the preferences, such that if the helper / page has a trait with a name suffix `_items` defined, it would not be mistaken as the event trait for list/set/dict mutation. Otherwise it would assume it is the event trait for list/set/dict mutation, and handle it specifically. If the assumption is wrong, the change handler will raise an error, but the error will be captured in a normal run condition and the default log message will appear.

This fix is possible because one cannot have a trait called `name` and a trait called `name_items` (not an event) and expect both of them to operate normally. Consider the following traits-only tests:
```
import unittest
from traits.api import *

class ItemsFirst(HasTraits):
    names_items = Str()
    names = List(Str)

class ItemsSecond(HasTraits):
    names = List(Str)
    names_items = Str()

class TestItems(unittest.TestCase):
    def test_mutate_fails_items_second(self):
        obj = ItemsSecond()
        obj.names_items = "Hello"
        obj.names = []
        with self.assertRaises(TraitError):
            obj.names.append("1")

    def test_assignment_fails(self):
        obj = ItemsFirst()
        obj.names = []
        obj.names.append("1")
        with self.assertRaises(TraitError):
            obj.names_items = "Hello"
```
The above tests pass. If there is a list called "names" and there is a trait called "names_items", the existence of the second trait will cause a lot of unexpected behaviours on its own already.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
