### PR TITLE
Remove all use of six 

### DIFF
--- a/apptools/io/h5/table_node.py
+++ b/apptools/io/h5/table_node.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import six
 from tables.table import Table as PyTablesTable
 
 
@@ -96,7 +95,7 @@ class H5TableNode(object):
             An array of column data with the column order matching that of
             `col_or_cols`.
         """
-        if isinstance(col_or_cols, six.string_types):
+        if isinstance(col_or_cols, str):
             return self._h5_table.col(col_or_cols)
 
         column_data = [self._h5_table.col(name) for name in col_or_cols]

--- a/apptools/io/h5/tests/test_dict_node.py
+++ b/apptools/io/h5/tests/test_dict_node.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_allclose
-import six
 
 from ..dict_node import H5DictNode
 from .utils import open_h5file, temp_h5_file, temp_file
@@ -161,14 +160,14 @@ class DictNodeTestCase(unittest.TestCase):
             h5dict = H5DictNode.add_to_h5file(h5, NODE, data)
             assert isinstance(h5dict["a_int"], int)
             assert isinstance(h5dict["a_float"], float)
-            assert isinstance(h5dict["a_str"], six.string_types)
+            assert isinstance(h5dict["a_str"], str)
 
     def test_mixed_type_list(self):
         with temp_h5_file() as h5:
             data = dict(a=[1, 1.0, "abc"])
             h5dict = H5DictNode.add_to_h5file(h5, NODE, data)
             for value, dtype in zip(
-                h5dict["a"], (int, float, six.string_types)
+                h5dict["a"], (int, float, str)
             ):
                 assert isinstance(value, dtype)
 

--- a/apptools/logger/log_point.py
+++ b/apptools/logger/log_point.py
@@ -21,7 +21,7 @@
 import inspect
 
 # Third-party library imports.
-from six import StringIO
+from io import StringIO
 
 
 def log_point(msg="\n"):

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -19,9 +19,7 @@ import glob
 import logging
 import os
 from os.path import join, splitext
-
-# Third-party library imports.
-import six.moves.cPickle as pickle
+import pickle
 
 # Enthought library imports.
 from apptools.io.api import File

--- a/apptools/naming/trait_defs/naming_traits.py
+++ b/apptools/naming/trait_defs/naming_traits.py
@@ -16,8 +16,6 @@
 
 import sys
 
-import six
-
 from traits.api import Trait, TraitHandler, TraitFactory
 
 from traits.trait_base import class_of, get_module_name
@@ -62,12 +60,12 @@ class NamingTraitHandler(TraitHandler):
         self.module = module
         self.aClass = aClass
         if (aClass is not None) and (
-            not isinstance(aClass, (six.string_types, type))
+            not isinstance(aClass, (str, type))
         ):
             self.aClass = aClass.__class__
 
     def validate(self, object, name, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             if value == "":
                 if self.or_none:
                     return ""
@@ -78,7 +76,7 @@ class NamingTraitHandler(TraitHandler):
             except:
                 self.validate_failed(object, name, value)
 
-        if isinstance(self.aClass, six.string_types):
+        if isinstance(self.aClass, str):
             self.resolve_class(object, name, value)
 
         if isinstance(value, Binding) and (

--- a/apptools/preferences/preference_binding.py
+++ b/apptools/preferences/preference_binding.py
@@ -5,9 +5,6 @@
 from traits.api import Any, HasTraits, Instance, Str, Undefined
 from traits.api import Str
 
-# Third-party librart imports.
-import six
-
 # Local imports.
 from .i_preferences import IPreferences
 from .package_globals import get_default_preferences
@@ -104,7 +101,7 @@ class PreferenceBinding(HasTraits):
 
         # If the trait type is 'Str' then we convert the raw value.
         elif type(handler) is Str:
-            value = six.text_type(value)
+            value = str(value)
 
         # Otherwise, we eval it!
         else:

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -5,9 +5,6 @@ from __future__ import print_function
 # Standard library imports.
 import logging, threading
 
-# Third-party library imports.
-import six
-
 # Enthought library imports.
 from traits.api import Any, Callable, Dict, HasTraits, Instance, List
 from traits.api import Property, Str, Undefined, provides
@@ -548,7 +545,7 @@ class Preferences(HasTraits):
         # everything must be unicode encoded so that ConfigObj configuration
         # can properly serialize the data. Python str are supposed to be ASCII
         # encoded.
-        value = six.text_type(value)
+        value = str(value)
 
         self._lk.acquire()
         old = self._preferences.get(key)

--- a/apptools/preferences/tests/py_config_file.py
+++ b/apptools/preferences/tests/py_config_file.py
@@ -1,8 +1,6 @@
 """ A Python based configuration file with hierarchical sections. """
 from __future__ import print_function
 
-import six
-
 
 class PyConfigFile(dict):
     """ A Python based configuration file with hierarchical sections. """
@@ -118,7 +116,7 @@ class PyConfigFile(dict):
 
         """
 
-        if isinstance(file_or_filename, six.string_types):
+        if isinstance(file_or_filename, str):
             f = open(file_or_filename, mode)
 
         else:

--- a/apptools/scripting/recorder.py
+++ b/apptools/scripting/recorder.py
@@ -9,10 +9,8 @@ TODO:
 # Copyright (c) 2008-2015, Enthought, Inc.
 # License: BSD Style.
 
+import builtins
 import warnings
-
-import six
-import six.moves.builtins
 
 from traits.api import (
     HasTraits,
@@ -404,10 +402,7 @@ class Recorder(HasTraits):
         """Save the recorded lines to the given file.  It does not close
         the file.
         """
-        if six.PY3:
-            file.write(self.get_code())
-        else:
-            file.write(six.text_type(self.get_code(), encoding="utf-8"))
+        file.write(self.get_code())
         file.flush()
 
     def record_function(self, func, args, kw):
@@ -535,7 +530,7 @@ class Recorder(HasTraits):
         nm = self._name_map
         result = ""
         builtin = False
-        if cname in six.moves.builtins.__dict__:
+        if cname in builtins.__dict__:
             builtin = True
             if hasattr(obj, "__name__"):
                 cname = obj.__name__
@@ -721,8 +716,7 @@ class Recorder(HasTraits):
     def _return_as_string(self, object):
         """Return a string given a returned object from a function."""
         result = ""
-        long_type = long if six.PY2 else int
-        ignore = (float, complex, bool, int, long_type, str)
+        ignore = (float, complex, bool, int, str)
         if object is not None and type(object) not in ignore:
             # If object is not know, register it.
             registry = self._registry
@@ -739,7 +733,7 @@ class Recorder(HasTraits):
         """Import a class if needed."""
         cname = cls.__name__
         result = ""
-        if cname not in six.moves.builtins.__dict__:
+        if cname not in builtins.__dict__:
             mod = cls.__module__
             typename = "%s.%s" % (mod, cname)
             if typename not in self._known_types:

--- a/apptools/sweet_pickle/__init__.py
+++ b/apptools/sweet_pickle/__init__.py
@@ -124,20 +124,20 @@ def loads(str, max_pass=-1):
 
 # We don't customize the Python pickler, though we do use the cPickle module
 # for improved performance.
-from six.moves.cPickle import Pickler
+from pickle import Pickler
 
 # Implement the dump and dumps methods so that all traits in a HasTraits object
 # get included in the pickle.
 def dump(obj, file, protocol=2):
     _flush_traits(obj)
-    from six.moves.cPickle import dump as d
+    from pickle import dump as d
 
     return d(obj, file, protocol)
 
 
 def dumps(obj, protocol=2):
     _flush_traits(obj)
-    from six.moves.cPickle import dumps as ds
+    from pickle import dumps as ds
 
     return ds(obj, protocol)
 

--- a/apptools/sweet_pickle/global_registry.py
+++ b/apptools/sweet_pickle/global_registry.py
@@ -39,9 +39,9 @@
 """
 
 try:
-    import six.moves._thread as _thread
+    import _thread
 except ImportError:
-    import six.moves._dummy_thread as _thread
+    import _dummy_thread
 
 
 ##############################################################################

--- a/apptools/type_manager/adapter_manager.py
+++ b/apptools/type_manager/adapter_manager.py
@@ -3,9 +3,6 @@
 # Standard library imports
 import warnings
 
-# Third-party imports
-import six
-
 # Enthought library imports.
 from traits.api import Dict, HasTraits, Instance, Property
 
@@ -146,7 +143,7 @@ class AdapterManager(HasTraits):
 
         """
 
-        if isinstance(adaptee_class, six.string_types):
+        if isinstance(adaptee_class, str):
             adaptee_class_name = adaptee_class
 
         else:

--- a/apptools/type_registry/tests/dummies.py
+++ b/apptools/type_registry/tests/dummies.py
@@ -1,7 +1,5 @@
 import abc
 
-import six
-
 
 class A(object):
     pass
@@ -23,7 +21,7 @@ class Mixed(A, D):
     pass
 
 
-class Abstract(six.with_metaclass(abc.ABCMeta, object)):
+class Abstract(metaclass=abc.ABCMeta):
     pass
 
 

--- a/apptools/type_registry/type_registry.py
+++ b/apptools/type_registry/type_registry.py
@@ -56,7 +56,7 @@ class TypeRegistry(object):
         obj : object
             The object to register.
         """
-        if isinstance(typ, six.string_types):
+        if isinstance(typ, str):
             # Check the cached types.
             for cls in self.type_map:
                 if _mod_name_key(cls) == typ:
@@ -99,7 +99,7 @@ class TypeRegistry(object):
         ------
         KeyError if the type is not registered.
         """
-        if isinstance(typ, six.string_types):
+        if isinstance(typ, str):
             if typ not in self.name_map:
                 # We may have it cached in the type map. We will have to
                 # iterate over all of the types to check.

--- a/apptools/type_registry/type_registry.py
+++ b/apptools/type_registry/type_registry.py
@@ -1,6 +1,3 @@
-import six
-
-
 def get_mro(obj_class):
     """Get a reasonable method resolution order of a class and its
     superclasses for both old-style and new-style classes.

--- a/setup.py
+++ b/setup.py
@@ -301,7 +301,6 @@ if __name__ == "__main__":
                         },
           install_requires=[
               'configobj',
-              'six',
               'traitsui',
           ],
           extras_require={


### PR DESCRIPTION
part of #120 

This PR removes all uses of `six` and replaces the occurrences with just the python 3 specific code. 

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
Not adding a news fragment as one already exists saying "Remove support for Python 2.7 and 3.5".  That is what is relevant to `apptools` users.
