### PR TITLE
Remove occurrences of `from __future__ import print_function`

### DIFF
--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -1,7 +1,5 @@
 """ The default implementation of a node in a preferences hierarchy. """
 
-from __future__ import print_function
-
 # Standard library imports.
 import logging
 import threading

--- a/apptools/preferences/scoped_preferences.py
+++ b/apptools/preferences/scoped_preferences.py
@@ -1,7 +1,5 @@
 """ A preferences node that adds the notion of preferences scopes. """
 
-from __future__ import print_function
-
 # Standard library imports.
 from os.path import join
 

--- a/apptools/preferences/tests/py_config_file.py
+++ b/apptools/preferences/tests/py_config_file.py
@@ -1,5 +1,4 @@
 """ A Python based configuration file with hierarchical sections. """
-from __future__ import print_function
 
 
 class PyConfigFile(dict):

--- a/apptools/preferences/ui/preferences_node.py
+++ b/apptools/preferences/ui/preferences_node.py
@@ -13,8 +13,6 @@
 # ------------------------------------------------------------------------------
 """ Abstract base class for a node in a preferences dialog. """
 
-from __future__ import print_function
-
 # Enthought library imports.
 from traits.api import Delegate, Instance
 


### PR DESCRIPTION
Part of #120 

This PR simply removes occurrences of `from __future__ import print_function` across the `apptools` codebase.

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
