### PR TITLE
Delete travis-ci-requirements.txt

### DIFF
--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -1,6 +1,0 @@
-git+http://github.com/enthought/traitsui.git#egg=traitsui
-configobj
-coverage
-tables
-pandas
-git+http://github.com/enthought/pyface.git#egg=pyface


### PR DESCRIPTION
This PR removes the unused `travis-ci-requirements.txt` file.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ The changes in this PR are not newsworthy.