### PR TITLE
Add a short documentation section about the io sub-package

### DIFF
--- a/docs/releases/upcoming/237.doc.rst
+++ b/docs/releases/upcoming/237.doc.rst
@@ -1,0 +1,1 @@
+Document the ``apptools.io`` and ``apptools.io.h5`` sub packages (#237)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ AppTools Documentation
     undo/*
     selection/*
     naming/*
+    io/*
     api
 
 * :ref:`search`

--- a/docs/source/io/introduction.rst
+++ b/docs/source/io/introduction.rst
@@ -1,24 +1,24 @@
 io
 ===
 
-The io package provides a traited |File| object provides properties and methods
-for common file path manipulation operations.  On Python 3 much of this
-functionality is provided by the `pathlib`_ module, and for new code we
-encourage users to investigate if `pathlib`_ can satisfy their usecase before
-they turn to the `apptools.io` |File| object
+The :mod:`apptools.io` package provides a traited |File| object provides
+properties and methods for common file path manipulation operations.  Much of
+this functionality was implemented before Python 3 `pathlib`_ standard library
+became available to provide similar support.  For new code we encourage users
+to investigate if `pathlib`_ can satisfy their use cases before they turn to
+the `apptools.io` |File| object
 
 io.h5
 -----
-The io.h5 sub-package provides a wrapper around `PyTables`_ with a
-dictionary-style mapping.  Note that this module has a decent amount of
-overlap with `zarr`_.
+The :mod:`apptools.io.h5` sub-package provides a wrapper around `PyTables`_
+with a dictionary-style mapping.
+
 
 ..
    external links
 
 .. _pathlib: https://docs.python.org/3/library/pathlib.html
 .. _PyTables: https://www.pytables.org/
-.. _zarr: https://zarr.readthedocs.io/en/stable/
 
 
 ..

--- a/docs/source/io/introduction.rst
+++ b/docs/source/io/introduction.rst
@@ -1,5 +1,5 @@
-io
-===
+File I/O
+========
 
 The :mod:`apptools.io` package provides a traited |File| object provides
 properties and methods for common file path manipulation operations.  Much of
@@ -8,8 +8,9 @@ became available to provide similar support.  For new code we encourage users
 to investigate if `pathlib`_ can satisfy their use cases before they turn to
 the `apptools.io` |File| object
 
-io.h5
------
+HDF5 File Support
+-----------------
+
 The :mod:`apptools.io.h5` sub-package provides a wrapper around `PyTables`_
 with a dictionary-style mapping.
 

--- a/docs/source/io/introduction.rst
+++ b/docs/source/io/introduction.rst
@@ -1,0 +1,27 @@
+io
+===
+
+The io package provides a traited |File| object provides properties and methods
+for common file path manipulation operations.  On Python 3 much of this
+functionality is provided by the `pathlib`_ module, and for new code we
+encourage users to investigate if `pathlib`_ can satisfy their usecase before
+they turn to the `apptools.io` |File| object
+
+io.h5
+-----
+The io.h5 sub-package provides a wrapper around `PyTables`_ with a
+dictionary-style mapping.  Note that this module has a decent amount of
+overlap with `zarr`_.
+
+..
+   external links
+
+.. _pathlib: https://docs.python.org/3/library/pathlib.html
+.. _PyTables: https://www.pytables.org/
+.. _zarr: https://zarr.readthedocs.io/en/stable/
+
+
+..
+   # substitutions
+
+.. |File| replace:: :class:`~apptools.io.file.File`


### PR DESCRIPTION
fixes #53 

This PR adds a _brief_ section to the documentation discussing the `apptools.io` and `apptools.io.h5` sub packages.
   
**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
