### PR TITLE
Final flake8 fixes

### DIFF
--- a/apptools/naming/__init__.py
+++ b/apptools/naming/__init__.py
@@ -15,4 +15,29 @@
     preferences. Part of the AppTools project of the Enthought Tool Suite.
 
 """
-from apptools.naming.api import *
+from .exception import NamingError, InvalidNameError, NameAlreadyBoundError
+from .exception import NameNotFoundError, NotContextError
+from .exception import OperationNotSupportedError
+
+from .address import Address
+from .binding import Binding
+from .context import Context
+from .dynamic_context import DynamicContext
+from .dir_context import DirContext
+from .initial_context import InitialContext
+from .initial_context_factory import InitialContextFactory
+from .naming_event import NamingEvent
+from .naming_manager import naming_manager
+from .object_factory import ObjectFactory
+from .object_serializer import ObjectSerializer
+from .py_context import PyContext
+from .py_object_factory import PyObjectFactory
+from .pyfs_context import PyFSContext
+from .pyfs_context_factory import PyFSContextFactory
+from .pyfs_initial_context_factory import PyFSInitialContextFactory
+from .pyfs_object_factory import PyFSObjectFactory
+from .pyfs_state_factory import PyFSStateFactory
+from .reference import Reference
+from .referenceable import Referenceable
+from .referenceable_state_factory import ReferenceableStateFactory
+from .state_factory import StateFactory

--- a/apptools/naming/context.py
+++ b/apptools/naming/context.py
@@ -15,18 +15,15 @@
 
 
 # Enthought library imports.
-from traits.api import Any, Dict, Event, HasTraits, Instance
+from traits.api import Any, Dict, Event, HasTraits
 from traits.api import Property, Str
 
 # Local imports.
 from .binding import Binding
 from .exception import InvalidNameError, NameAlreadyBoundError
 from .exception import NameNotFoundError, NotContextError
-from .exception import OperationNotSupportedError
 from .naming_event import NamingEvent
 from .naming_manager import naming_manager
-from .object_factory import ObjectFactory
-from .state_factory import StateFactory
 from .unique_name import make_unique_name
 
 
@@ -703,7 +700,7 @@ class Context(HasTraits):
 
             if (
                 isinstance(binding.obj, Context)
-                and not binding.obj in searched
+                and binding.obj not in searched
             ):
                 path.append(binding.name)
                 searched[binding.obj] = True

--- a/apptools/naming/dir_context.py
+++ b/apptools/naming/dir_context.py
@@ -19,7 +19,7 @@ from traits.api import Dict
 
 # Local imports.
 from .context import Context
-from .exception import NameNotFoundError, NotContextError
+from .exception import NameNotFoundError
 
 
 class DirContext(Context):

--- a/apptools/naming/dynamic_context.py
+++ b/apptools/naming/dynamic_context.py
@@ -82,7 +82,7 @@ class DynamicContext(Context):
         item = self._get_contributed_context_item(name)
         if item != (None, None):
             obj, trait = item
-            result = True == trait.is_context
+            result = trait.is_context is True
         else:
             result = False
 
@@ -168,7 +168,7 @@ class DynamicContext(Context):
         traits = [(t.context_order, n, t) for n, t in traits.items()]
         traits.sort()
 
-        # Convert these trait definitions into a list of name and object tuples.
+        # Convert these trait definitions into a list of name and object tuples
         result = [
             (t.context_name, getattr(self, n), t) for order, n, t in traits
         ]

--- a/apptools/naming/dynamic_context.py
+++ b/apptools/naming/dynamic_context.py
@@ -82,7 +82,7 @@ class DynamicContext(Context):
         item = self._get_contributed_context_item(name)
         if item != (None, None):
             obj, trait = item
-            result = True if trait.is_context is True else False
+            result = trait.is_context is True
         else:
             result = False
 

--- a/apptools/naming/object_serializer.py
+++ b/apptools/naming/object_serializer.py
@@ -55,7 +55,7 @@ class ObjectSerializer(HasTraits):
         f = open(path, "rb")
         try:
             try:
-                 obj = VersionedUnpickler(f).load()
+                obj = VersionedUnpickler(f).load()
             except Exception as ex:
                 print_exc()
                 logger.exception(

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -231,7 +231,7 @@ class PyFSContext(DirContext, Referenceable):
                     # If the load fails then we create a generic file resource
                     # (the idea being that it might be useful to have access to
                     # the file to see what went wrong).
-                    except Exception:
+                    except:  # noqa: E722
                         state = File(path)
                         logger.exception("Error loading resource at %s" % path)
 

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -30,7 +30,6 @@ from .address import Address
 from .binding import Binding
 from .context import Context
 from .dir_context import DirContext
-from .exception import NameNotFoundError, NotContextError
 from .naming_event import NamingEvent
 from .naming_manager import naming_manager
 from .object_serializer import ObjectSerializer
@@ -152,7 +151,7 @@ class PyFSContext(DirContext, Referenceable):
         if "root" in self.environment:
             root = self.environment["root"]
 
-            namespace_name = self.path[len(root) + 1 :]
+            namespace_name = self.path[len(root) + 1:]
 
         else:
             namespace_name = self.path
@@ -232,7 +231,7 @@ class PyFSContext(DirContext, Referenceable):
                     # If the load fails then we create a generic file resource
                     # (the idea being that it might be useful to have access to
                     # the file to see what went wrong).
-                    except:
+                    except Exception:
                         state = File(path)
                         logger.exception("Error loading resource at %s" % path)
 

--- a/apptools/naming/reference.py
+++ b/apptools/naming/reference.py
@@ -15,7 +15,7 @@
 
 
 # Enthought library imports.
-from traits.api import Any, HasPrivateTraits, List, Str
+from traits.api import HasPrivateTraits, List, Str
 
 # Local imports.
 from .address import Address

--- a/apptools/naming/tests/test_context.py
+++ b/apptools/naming/tests/test_context.py
@@ -18,7 +18,15 @@
 import unittest
 
 # Enthought library imports.
-from apptools.naming.api import *
+from apptools.naming.api import (
+    Context,
+    InvalidNameError,
+    NameAlreadyBoundError,
+    NameNotFoundError,
+    NotContextError,
+    ObjectFactory,
+    StateFactory,
+)
 
 
 class ContextTestCase(unittest.TestCase):
@@ -480,7 +488,7 @@ class ContextTestCase(unittest.TestCase):
         # Convenience.
         context = self.context
         sub = self.context.lookup("sub")
-        sub_sibling = context.create_subcontext("sub sibling")
+        context.create_subcontext("sub sibling")
         sub_sub = sub.create_subcontext("sub sub")
 
         context.bind("one", 1)

--- a/apptools/naming/tests/test_dir_context.py
+++ b/apptools/naming/tests/test_dir_context.py
@@ -15,7 +15,11 @@
 
 
 # Enthought library imports.
-from apptools.naming.api import *
+from apptools.naming.api import (
+    DirContext,
+    NameNotFoundError,
+    NotContextError,
+)
 
 # Local imports.
 from .test_context import ContextTestCase

--- a/apptools/naming/tests/test_object_serializer.py
+++ b/apptools/naming/tests/test_object_serializer.py
@@ -30,6 +30,7 @@ class FooWithTraits(HasTraits):
     def _get_last_name(self):
         return self.full_name.split(" ")[-1]
 
+
 class TestObjectSerializer(unittest.TestCase):
 
     def setUp(self):

--- a/apptools/naming/tests/test_pyfs_context.py
+++ b/apptools/naming/tests/test_pyfs_context.py
@@ -15,11 +15,20 @@
 
 
 # Standard library imports.
-import os, shutil, unittest
+import os
+import shutil
+import unittest
 
 # Enthought library imports.
 from apptools.io import File
-from apptools.naming.api import *
+from apptools.naming.api import (
+    DirContext,
+    InvalidNameError,
+    NameAlreadyBoundError,
+    NameNotFoundError,
+    NotContextError,
+    PyFSContext,
+)
 
 
 class PyFSContextTestCase(unittest.TestCase):
@@ -32,14 +41,10 @@ class PyFSContextTestCase(unittest.TestCase):
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
-        try:
-            if os.path.exists("data"):
-                shutil.rmtree("data")
-            if os.path.exists("other"):
-                shutil.rmtree("other")
-
-        except:
-            pass
+        if os.path.exists("data"):
+            shutil.rmtree("data", ignore_errors=True)
+        if os.path.exists("other"):
+            shutil.rmtree("other", ignore_errors=True)
 
         os.mkdir("data")
         os.mkdir("other")
@@ -248,7 +253,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertRaises(InvalidNameError, context.create_subcontext, "")
 
         # Create a sub-context.
-        a = context.create_subcontext("sub/a")
+        context.create_subcontext("sub/a")
         self.assertEqual(len(sub.list_bindings("")), 1)
         self.assertTrue(os.path.isdir(os.path.join(sub.path, "a")))
 
@@ -273,7 +278,7 @@ class PyFSContextTestCase(unittest.TestCase):
         self.assertRaises(InvalidNameError, context.destroy_subcontext, "")
 
         # Create a sub-context.
-        a = context.create_subcontext("sub/a")
+        context.create_subcontext("sub/a")
         self.assertEqual(len(sub.list_bindings("")), 1)
 
         # Destroy it.

--- a/apptools/naming/trait_defs/__init__.py
+++ b/apptools/naming/trait_defs/__init__.py
@@ -14,4 +14,4 @@
 #  Imports:
 # ------------------------------------------------------------------------------
 
-from apptools.naming.trait_defs.api import *
+from .naming_traits import NamingInstance

--- a/apptools/naming/trait_defs/naming_traits.py
+++ b/apptools/naming/trait_defs/naming_traits.py
@@ -20,8 +20,6 @@ from traits.api import Trait, TraitHandler, TraitFactory
 
 from traits.trait_base import class_of, get_module_name
 
-from traitsui.api import DropEditor
-
 from apptools.naming.api import Binding
 
 
@@ -56,7 +54,7 @@ class NamingTraitHandler(TraitHandler):
 
     def __init__(self, aClass, or_none, module):
         """Initializes the object."""
-        self.or_none = or_none != False
+        self.or_none = or_none is not False
         self.module = module
         self.aClass = aClass
         if (aClass is not None) and (
@@ -73,7 +71,7 @@ class NamingTraitHandler(TraitHandler):
                     self.validate_failed(object, name, value)
             try:
                 value = self._get_binding_for(value)
-            except:
+            except Exception:
                 self.validate_failed(object, name, value)
 
         if isinstance(self.aClass, str):
@@ -123,10 +121,10 @@ class NamingTraitHandler(TraitHandler):
 
         result = None
 
-        # FIXME: The following code makes this whole component have a dependency
-        # on envisage, and worse, assumes the use of a particular project
-        # plugin!  This is horrible and should be refactored out, possibly to
-        # a custom sub-class of whoever needs this behavior.
+        # FIXME: The following code makes this whole component have a
+        # dependency on envisage, and worse, assumes the use of a particular
+        # project plugin!  This is horrible and should be refactored out,
+        # possibly to a custom sub-class of whoever needs this behavior.
         try:
             from envisage import get_application
 
@@ -146,8 +144,8 @@ class NamingTraitHandler(TraitHandler):
         self.aClass = aClass
 
         # fixme: The following is quite ugly, because it wants to try and fix
-        # the trait referencing this handler to use the 'fast path' now that the
-        # actual class has been resolved. The problem is finding the trait,
+        # the trait referencing this handler to use the 'fast path' now that
+        # the actual class has been resolved. The problem is finding the trait,
         # especially in the case of List(Instance('foo')), where the
         # object.base_trait(...) value is the List trait, not the Instance
         # trait, so we need to check for this and pull out the List
@@ -165,11 +163,11 @@ class NamingTraitHandler(TraitHandler):
         col = aClass.rfind(".")
         if col >= 0:
             module = aClass[:col]
-            aClass = aClass[col + 1 :]
+            aClass = aClass[col + 1:]
         theClass = getattr(sys.modules.get(module), aClass, None)
         if (theClass is None) and (col >= 0):
             try:
                 theClass = getattr(__import__(module), aClass, None)
-            except:
+            except Exception:
                 pass
         return theClass

--- a/apptools/naming/trait_defs/naming_traits.py
+++ b/apptools/naming/trait_defs/naming_traits.py
@@ -71,7 +71,7 @@ class NamingTraitHandler(TraitHandler):
                     self.validate_failed(object, name, value)
             try:
                 value = self._get_binding_for(value)
-            except Exception:
+            except:  # noqa: E722
                 self.validate_failed(object, name, value)
 
         if isinstance(self.aClass, str):

--- a/etstool.py
+++ b/etstool.py
@@ -157,7 +157,8 @@ def install(runtime, environment, source):
     commands = [
         "edm environments create {environment} --force --version={runtime}",
         "edm install -y -e {environment} " + packages,
-        "edm run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
+        "edm run -e {environment} -- pip install -r ci-src-requirements.txt"
+        " --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
         "edm run -e {environment} -- python setup.py develop"
     ]
@@ -213,6 +214,7 @@ def test(runtime, environment):
         execute(commands, parameters)
     click.echo('Done test')
 
+
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--environment', default=None)
@@ -239,6 +241,7 @@ def docs(runtime, environment):
 
     commands = [apidoc_command, html_build_command]
     execute(commands, parameters)
+
 
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
@@ -290,6 +293,7 @@ def test_clean(runtime):
         test(args=args, standalone_mode=False)
     finally:
         cleanup(args=args, standalone_mode=False)
+
 
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
@@ -424,7 +428,9 @@ def get_parameters(runtime, environment):
     """ Set up parameters dictionary for format() substitution """
     parameters = {'runtime': runtime, 'environment': environment}
     if environment is None:
-        parameters['environment'] = 'apptools-test-{runtime}'.format(**parameters)
+        parameters['environment'] = 'apptools-test-{runtime}'.format(
+            **parameters
+        )
     return parameters
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
 [flake8]
 ignore = E266, W503
 per-file-ignores = */api.py:F401, */__init__.py:F401
-exclude =
-    # The following list should eventually be empty.
-    examples/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,4 @@ ignore = E266, W503
 per-file-ignores = */api.py:F401, */__init__.py:F401
 exclude =
     # The following list should eventually be empty.
-    etstool.py
     examples/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,5 @@ ignore = E266, W503
 per-file-ignores = */api.py:F401, */__init__.py:F401
 exclude =
     # The following list should eventually be empty.
-    apptools/naming/*
     etstool.py
     examples/*


### PR DESCRIPTION
fixes #145 

After this PR, the `setup.cfg` exclude section is entirely empty.  We still have the per-file-ignores for F401 errors in `api` and `__init__` files which should stay.  We also still ignore E266 and W503 errors but I believe that is intended to remain the case.  

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
