### PR TITLE
Update and check Copyright headers

### DIFF
--- a/apptools/__init__.py
+++ b/apptools/__init__.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2007-2014 by Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 try:
     from apptools.version import version as __version__

--- a/apptools/io/__init__.py
+++ b/apptools/io/__init__.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought IO package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Provides an abstraction for files and folders in a file system.
     Part of the AppTools project of the Enthought Tool Suite.
 """

--- a/apptools/io/api.py
+++ b/apptools/io/api.py
@@ -1,14 +1,10 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought IO package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 from .file import File

--- a/apptools/io/file.py
+++ b/apptools/io/file.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought IO package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A representation of files and folders in a file system. """
 
 

--- a/apptools/io/h5/__init__.py
+++ b/apptools/io/h5/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/io/h5/dict_node.py
+++ b/apptools/io/h5/dict_node.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from contextlib import closing
 import json
 

--- a/apptools/io/h5/file.py
+++ b/apptools/io/h5/file.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from collections import Mapping, MutableMapping
 from functools import partial
 import inspect

--- a/apptools/io/h5/table_node.py
+++ b/apptools/io/h5/table_node.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import numpy as np
 
 from tables.table import Table as PyTablesTable

--- a/apptools/io/h5/tests/__init__.py
+++ b/apptools/io/h5/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/io/h5/tests/test_dict_node.py
+++ b/apptools/io/h5/tests/test_dict_node.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 import numpy as np

--- a/apptools/io/h5/tests/test_file.py
+++ b/apptools/io/h5/tests/test_file.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import os
 from contextlib import closing
 import unittest

--- a/apptools/io/h5/tests/test_table_node.py
+++ b/apptools/io/h5/tests/test_table_node.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 from apptools._testing.optional_dependencies import (

--- a/apptools/io/h5/tests/utils.py
+++ b/apptools/io/h5/tests/utils.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from contextlib import contextmanager
 import tempfile
 import os

--- a/apptools/io/h5/utils.py
+++ b/apptools/io/h5/utils.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from contextlib import contextmanager
 
 from .file import H5File

--- a/apptools/io/tests/__init__.py
+++ b/apptools/io/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/io/tests/test_file.py
+++ b/apptools/io/tests/test_file.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought IO package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests file operations. """
 
 

--- a/apptools/io/tests/test_folder.py
+++ b/apptools/io/tests/test_folder.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought IO package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests folder operations. """
 
 

--- a/apptools/logger/__init__.py
+++ b/apptools/logger/__init__.py
@@ -1,9 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2005 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Convenience functions for creating logging handlers.
     Part of the EnthoughtBase project.
 """

--- a/apptools/logger/agent/__init__.py
+++ b/apptools/logger/agent/__init__.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 lib.apptools.logger.agent
 """

--- a/apptools/logger/agent/attachments.py
+++ b/apptools/logger/agent/attachments.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Attach relevant project files.
 
 FIXME: there are no public project plugins for Envisage 3, yet. In any case,

--- a/apptools/logger/agent/quality_agent_mailer.py
+++ b/apptools/logger/agent/quality_agent_mailer.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # Standard library imports.
 import logging

--- a/apptools/logger/agent/quality_agent_view.py
+++ b/apptools/logger/agent/quality_agent_view.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # Standard library imports.
 import logging

--- a/apptools/logger/agent/tests/__init__.py
+++ b/apptools/logger/agent/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/logger/agent/tests/test_attachments.py
+++ b/apptools/logger/agent/tests/test_attachments.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from email.mime.multipart import MIMEMultipart
 import io
 import os

--- a/apptools/logger/api.py
+++ b/apptools/logger/api.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from .logger import add_log_queue_handler
 from .logger import FORMATTER, LEVEL, LogFileHandler
 from .log_point import log_point

--- a/apptools/logger/custom_excepthook.py
+++ b/apptools/logger/custom_excepthook.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 
 # Standard library imports.

--- a/apptools/logger/log_point.py
+++ b/apptools/logger/log_point.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Prints a stack trace every time it is called but does not halt execution
     of the application.
 

--- a/apptools/logger/log_queue_handler.py
+++ b/apptools/logger/log_queue_handler.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # Standard library imports.
 from logging import Handler

--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Convenience functions for creating logging handlers etc. """
 
 

--- a/apptools/logger/plugin/__init__.py
+++ b/apptools/logger/plugin/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/logger/plugin/logger_plugin.py
+++ b/apptools/logger/plugin/logger_plugin.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Logger plugin.
 """
 

--- a/apptools/logger/plugin/logger_preferences.py
+++ b/apptools/logger/plugin/logger_preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import logging
 
 from apptools.preferences.api import PreferencesHelper

--- a/apptools/logger/plugin/logger_service.py
+++ b/apptools/logger/plugin/logger_service.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 # Standard library imports
 import logging
 import os

--- a/apptools/logger/plugin/tests/__init__.py
+++ b/apptools/logger/plugin/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/logger/plugin/tests/test_logger_service.py
+++ b/apptools/logger/plugin/tests/test_logger_service.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from email.mime.multipart import MIMEMultipart
 import unittest
 from unittest import mock

--- a/apptools/logger/plugin/view/__init__.py
+++ b/apptools/logger/plugin/view/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/logger/plugin/view/logger_preferences_page.py
+++ b/apptools/logger/plugin/view/logger_preferences_page.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 import logging
 

--- a/apptools/logger/plugin/view/logger_view.py
+++ b/apptools/logger/plugin/view/logger_view.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought logger package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # Standard library imports
 from datetime import datetime

--- a/apptools/logger/ring_buffer.py
+++ b/apptools/logger/ring_buffer.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought util package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """
 Copied from Python Cookbook.
 

--- a/apptools/naming/__init__.py
+++ b/apptools/naming/__init__.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Manages naming contexts. Supports non-string data types and scoped
     preferences. Part of the AppTools project of the Enthought Tool Suite.
 

--- a/apptools/naming/address.py
+++ b/apptools/naming/address.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The address of a commuications endpoint. """
 
 

--- a/apptools/naming/api.py
+++ b/apptools/naming/api.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 from .exception import NamingError, InvalidNameError, NameAlreadyBoundError
 from .exception import NameNotFoundError, NotContextError
 from .exception import OperationNotSupportedError

--- a/apptools/naming/binding.py
+++ b/apptools/naming/binding.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The representation of a name-to-object binding in a context. """
 
 

--- a/apptools/naming/context.py
+++ b/apptools/naming/context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all naming contexts. """
 
 

--- a/apptools/naming/dir_context.py
+++ b/apptools/naming/dir_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all directory contexts. """
 
 

--- a/apptools/naming/dynamic_context.py
+++ b/apptools/naming/dynamic_context.py
@@ -1,9 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2006 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 """ Provider of a framework that dynamically determines the contents of a
     context at the time of interaction with the contents rather than at the

--- a/apptools/naming/exception.py
+++ b/apptools/naming/exception.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Naming exceptions. """
 
 

--- a/apptools/naming/initial_context.py
+++ b/apptools/naming/initial_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The starting point for performing naming operations. """
 
 

--- a/apptools/naming/initial_context_factory.py
+++ b/apptools/naming/initial_context_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all initial context factories. """
 
 

--- a/apptools/naming/naming_event.py
+++ b/apptools/naming/naming_event.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The event fired by the tree model when it changes. """
 
 

--- a/apptools/naming/naming_manager.py
+++ b/apptools/naming/naming_manager.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The naming manager. """
 
 

--- a/apptools/naming/object_factory.py
+++ b/apptools/naming/object_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all object factories. """
 
 

--- a/apptools/naming/object_serializer.py
+++ b/apptools/naming/object_serializer.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all object serializers. """
 
 

--- a/apptools/naming/py_context.py
+++ b/apptools/naming/py_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A naming context for a Python namespace. """
 
 

--- a/apptools/naming/py_object_factory.py
+++ b/apptools/naming/py_object_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Object factory for Python namespace contexts. """
 
 

--- a/apptools/naming/pyfs_context.py
+++ b/apptools/naming/pyfs_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A Python File System context. """
 
 

--- a/apptools/naming/pyfs_context_factory.py
+++ b/apptools/naming/pyfs_context_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Object factory for Python File System contexts. """
 
 

--- a/apptools/naming/pyfs_initial_context_factory.py
+++ b/apptools/naming/pyfs_initial_context_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The initial context factory for Python file system contexts. """
 
 

--- a/apptools/naming/pyfs_object_factory.py
+++ b/apptools/naming/pyfs_object_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Object factory for Python File System contexts. """
 
 

--- a/apptools/naming/pyfs_state_factory.py
+++ b/apptools/naming/pyfs_state_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ State factory for Python File System contexts. """
 
 

--- a/apptools/naming/reference.py
+++ b/apptools/naming/reference.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A reference to an object that lives outside of the naming system. """
 
 

--- a/apptools/naming/referenceable.py
+++ b/apptools/naming/referenceable.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Base class for classes that can produce a reference to themselves. """
 
 

--- a/apptools/naming/referenceable_state_factory.py
+++ b/apptools/naming/referenceable_state_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ State factory for referenceable objects. """
 
 

--- a/apptools/naming/state_factory.py
+++ b/apptools/naming/state_factory.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ The base class for all state factories. """
 
 

--- a/apptools/naming/tests/__init__.py
+++ b/apptools/naming/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/naming/tests/test_context.py
+++ b/apptools/naming/tests/test_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests operations that span contexts. """
 
 

--- a/apptools/naming/tests/test_dir_context.py
+++ b/apptools/naming/tests/test_dir_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests the default directory context. """
 
 

--- a/apptools/naming/tests/test_py_context.py
+++ b/apptools/naming/tests/test_py_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests the Python namespace context. """
 
 

--- a/apptools/naming/tests/test_pyfs_context.py
+++ b/apptools/naming/tests/test_pyfs_context.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Tests naming operations on PyFS contexts. """
 
 

--- a/apptools/naming/trait_defs/__init__.py
+++ b/apptools/naming/trait_defs/__init__.py
@@ -1,14 +1,12 @@
-# ------------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Define traits useful with Naming.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Written by: David C. Morrill
-#
-#  Date: 08/16/2005
-#
-#  (c) Copyright 2005 by Enthought, Inc.
-#
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # ------------------------------------------------------------------------------
 #  Imports:

--- a/apptools/naming/trait_defs/api.py
+++ b/apptools/naming/trait_defs/api.py
@@ -1,13 +1,10 @@
-# ------------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Define traits useful with Naming.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Written by: David C. Morrill
-#
-#  Date: 08/16/2005
-#
-#  (c) Copyright 2005 by Enthought, Inc.
-#
-# ------------------------------------------------------------------------------
-
+# Thanks for using Enthought open source!
 from .naming_traits import NamingInstance

--- a/apptools/naming/trait_defs/naming_traits.py
+++ b/apptools/naming/trait_defs/naming_traits.py
@@ -1,14 +1,12 @@
-# -------------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Defines the NamingLog and NamingIndex traits
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Written by: David C. Morrill
-#
-#  Date: 08/15/2005
-#
-#  (c) Copyright 2005 by Enthought, Inc.
-#
-# -------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # -------------------------------------------------------------------------------
 #  Imports:

--- a/apptools/naming/unique_name.py
+++ b/apptools/naming/unique_name.py
@@ -1,9 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2007 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 
 """

--- a/apptools/persistence/__init__.py
+++ b/apptools/persistence/__init__.py
@@ -1,7 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2004 by Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
-# ------------------------------------------------------------------------------
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Supports flexible pickling and unpickling of the state of a Python object
     to a dictionary. Part of the AppTools project of the Enthought Tool Suite.
 """

--- a/apptools/persistence/file_path.py
+++ b/apptools/persistence/file_path.py
@@ -1,10 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """Simple class to support file path objects that work well in the
 context of persistent storage with the state_pickler.
 
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
-# License: BSD Style.
 
 # Standard library imports.
 import os

--- a/apptools/persistence/project_loader.py
+++ b/apptools/persistence/project_loader.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 # Standard library imports
 import sys
 import pickle

--- a/apptools/persistence/state_pickler.py
+++ b/apptools/persistence/state_pickler.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """This module provides code that allows one to pickle the state of a
 Python object to a dictionary.
 

--- a/apptools/persistence/tests/__init__.py
+++ b/apptools/persistence/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/persistence/tests/state_function_classes.py
+++ b/apptools/persistence/tests/state_function_classes.py
@@ -1,11 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2006 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Author: Dave Peterson <dpeterson@enthought.com>
-#
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 # Standard library imports
 import logging

--- a/apptools/persistence/tests/test_class_mapping.py
+++ b/apptools/persistence/tests/test_class_mapping.py
@@ -1,11 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2006 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Author: Dave Peterson <dpeterson@enthought.com>
-#
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 """ Tests the class mapping functionality of the enthought.pickle
     framework.

--- a/apptools/persistence/tests/test_file_path.py
+++ b/apptools/persistence/tests/test_file_path.py
@@ -1,9 +1,15 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """Tests for the file_path module.
 
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
-# License: BSD Style.
 
 # Standard library imports.
 import unittest

--- a/apptools/persistence/tests/test_state_function.py
+++ b/apptools/persistence/tests/test_state_function.py
@@ -1,11 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2006 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Author: Dave Peterson <dpeterson@enthought.com>
-#
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 """ These tests were originally for the the state function functionality of the
 now deleted apptools.sweet_pickle framework.  They have been modified here to

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -1,9 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """Unit tests for the state pickler and unpickler.
 
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2015, Enthought, Inc.
-# License: BSD Style.
 
 import base64
 import pickle

--- a/apptools/persistence/tests/test_two_stage_unpickler.py
+++ b/apptools/persistence/tests/test_two_stage_unpickler.py
@@ -1,11 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2008 by Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Author: Dave Peterson <dpeterson@enthought.com>
-#          Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 """ This was previously a test for the now deleted apptools.sweet_pickle
 sub package.  It is included here to showcase how apptools.persistance can be

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -1,9 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """Tests for the version registry.
 
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
-# License: BSD Style.
 
 # Standard library imports.
 from importlib import reload

--- a/apptools/persistence/updater.py
+++ b/apptools/persistence/updater.py
@@ -7,6 +7,8 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
+
 def __replacement_setstate__(self, state):
     """"""
     state = self.__updater__(state)

--- a/apptools/persistence/updater.py
+++ b/apptools/persistence/updater.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 def __replacement_setstate__(self, state):
     """"""
     state = self.__updater__(state)

--- a/apptools/persistence/version_registry.py
+++ b/apptools/persistence/version_registry.py
@@ -1,9 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """A version registry that manages handlers for different state
 versions.
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
-# License: BSD Style.
+
 
 # Standard library imports.
 import sys

--- a/apptools/persistence/versioned_unpickler.py
+++ b/apptools/persistence/versioned_unpickler.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 # Standard library imports
 from pickle import _Unpickler as Unpickler
 from pickle import UnpicklingError, BUILD

--- a/apptools/preferences/__init__.py
+++ b/apptools/preferences/__init__.py
@@ -1,5 +1,12 @@
-# Copyright (c) 2007-2011 by Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Manages application preferences.
     Part of the AppTools project of the Enthought Tool Suite
 """

--- a/apptools/preferences/api.py
+++ b/apptools/preferences/api.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from .i_preferences import IPreferences
 
 from .package_globals import get_default_preferences, set_default_preferences

--- a/apptools/preferences/i_preferences.py
+++ b/apptools/preferences/i_preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ The interface for a node in a preferences hierarchy. """
 
 

--- a/apptools/preferences/package_globals.py
+++ b/apptools/preferences/package_globals.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Package-scope globals.
 
 The default preferences node is currently used by 'PreferencesHelper' and

--- a/apptools/preferences/preference_binding.py
+++ b/apptools/preferences/preference_binding.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ A binding between a trait on an object and a preference value. """
 
 

--- a/apptools/preferences/preferences.py
+++ b/apptools/preferences/preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ The default implementation of a node in a preferences hierarchy. """
 
 # Standard library imports.

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ An object that can be initialized from a preferences node. """
 
 

--- a/apptools/preferences/scoped_preferences.py
+++ b/apptools/preferences/scoped_preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ A preferences node that adds the notion of preferences scopes. """
 
 # Standard library imports.

--- a/apptools/preferences/tests/__init__.py
+++ b/apptools/preferences/tests/__init__.py
@@ -1,2 +1,9 @@
-# Copyright (c) 2007-2011 by Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/preferences/tests/py_config_file.py
+++ b/apptools/preferences/tests/py_config_file.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ A Python based configuration file with hierarchical sections. """
 
 

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for preference bindings. """
 
 

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for preferences nodes. """
 
 

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for the preferences helper. """
 
 

--- a/apptools/preferences/tests/test_py_config_file.py
+++ b/apptools/preferences/tests/test_py_config_file.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for Python-esque '.ini' files. """
 
 

--- a/apptools/preferences/tests/test_scoped_preferences.py
+++ b/apptools/preferences/tests/test_scoped_preferences.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for scoped preferences. """
 
 

--- a/apptools/preferences/ui/__init__.py
+++ b/apptools/preferences/ui/__init__.py
@@ -1,2 +1,9 @@
-# Copyright (c) 2007-2011 by Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/preferences/ui/api.py
+++ b/apptools/preferences/ui/api.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from .i_preferences_page import IPreferencesPage
 
 from .preferences_manager import PreferencesManager

--- a/apptools/preferences/ui/i_preferences_page.py
+++ b/apptools/preferences/ui/i_preferences_page.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ The interface for pages in a preferences dialog. """
 
 

--- a/apptools/preferences/ui/preferences_manager.py
+++ b/apptools/preferences/ui/preferences_manager.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ The preferences manager. """
 
 

--- a/apptools/preferences/ui/preferences_node.py
+++ b/apptools/preferences/ui/preferences_node.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ Abstract base class for a node in a preferences dialog. """
 
 # Enthought library imports.

--- a/apptools/preferences/ui/preferences_page.py
+++ b/apptools/preferences/ui/preferences_page.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ A page in a preferences dialog. """
 
 

--- a/apptools/preferences/ui/tests/__init__.py
+++ b/apptools/preferences/ui/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/preferences/ui/tests/test_preferences_page.py
+++ b/apptools/preferences/ui/tests/test_preferences_page.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ Tests for the preferences page. """
 
 import unittest

--- a/apptools/preferences/ui/tree_item.py
+++ b/apptools/preferences/ui/tree_item.py
@@ -1,16 +1,12 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A generic base-class for items in a tree data structure.
 
 An example:-

--- a/apptools/preferences/ui/widget_editor.py
+++ b/apptools/preferences/ui/widget_editor.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ An instance editor that allows total control over widget creation. """
 
 

--- a/apptools/scripting/__init__.py
+++ b/apptools/scripting/__init__.py
@@ -1,13 +1,12 @@
-# Copyright (c) 2008-2011, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Prabhu Ramachandran
+# Thanks for using Enthought open source!
 """ Automatic script recording framework, part of the AppTools project
     of the Enthought Tool Suite.
 """

--- a/apptools/scripting/api.py
+++ b/apptools/scripting/api.py
@@ -1,8 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """Public API for the scripting package.
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran and Enthought, Inc.
-# License: BSD Style.
 
 from .recorder import Recorder, RecorderError
 from .recordable import recordable

--- a/apptools/scripting/package_globals.py
+++ b/apptools/scripting/package_globals.py
@@ -1,9 +1,15 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 Globals for the scripting package.
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran and Enthought, Inc.
-# License: BSD Style.
 
 
 # The global recorder.

--- a/apptools/scripting/recordable.py
+++ b/apptools/scripting/recordable.py
@@ -1,9 +1,15 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 Decorator to mark functions and methods as recordable.
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran and Enthought, Inc.
-# License: BSD Style.
 
 from .package_globals import get_recorder
 

--- a/apptools/scripting/recorder.py
+++ b/apptools/scripting/recorder.py
@@ -1,12 +1,18 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 Code to support recording to a readable and executable Python script.
 
 FIXME:
     - Support for dictionaries?
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2015, Enthought, Inc.
-# License: BSD Style.
 
 import builtins
 import warnings

--- a/apptools/scripting/recorder_with_ui.py
+++ b/apptools/scripting/recorder_with_ui.py
@@ -1,9 +1,15 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 A Recorder subclass that presents a simple user interface.
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran.
-# License: BSD Style.
 
 from traits.api import Code, Button, Int, on_trait_change, Any
 from traitsui.api import View, Item, Group, HGroup, CodeEditor, spring, Handler

--- a/apptools/scripting/tests/__init__.py
+++ b/apptools/scripting/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -1,9 +1,15 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """
 Unit tests for the script recorder.
 """
-# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2015, Enthought, Inc.
-# License: BSD Style.
 
 import unittest
 

--- a/apptools/scripting/util.py
+++ b/apptools/scripting/util.py
@@ -1,8 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """Simple utility functions provided by the scripting API.
 """
-# Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
-# License: BSD Style.
 
 from .recorder import Recorder
 from .recorder_with_ui import RecorderWithUI

--- a/apptools/selection/__init__.py
+++ b/apptools/selection/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/selection/api.py
+++ b/apptools/selection/api.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from .errors import (
     IDConflictError,
     ListenerNotConnectedError,

--- a/apptools/selection/errors.py
+++ b/apptools/selection/errors.py
@@ -1,3 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
 class ProviderNotRegisteredError(Exception):
     """ Raised when a provider is requested by ID and not found. """
 

--- a/apptools/selection/i_selection.py
+++ b/apptools/selection/i_selection.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from traits.api import Interface, List, Str
 
 

--- a/apptools/selection/i_selection_provider.py
+++ b/apptools/selection/i_selection_provider.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from traits.api import Event, Interface, Str
 
 

--- a/apptools/selection/list_selection.py
+++ b/apptools/selection/list_selection.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from traits.api import HasTraits, List, provides, Str
 
 from apptools.selection.i_selection import IListSelection

--- a/apptools/selection/selection_service.py
+++ b/apptools/selection/selection_service.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from traits.api import Dict, HasTraits
 
 from apptools.selection.errors import (

--- a/apptools/selection/tests/__init__.py
+++ b/apptools/selection/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/selection/tests/test_list_selection.py
+++ b/apptools/selection/tests/test_list_selection.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 import numpy

--- a/apptools/selection/tests/test_selection_service.py
+++ b/apptools/selection/tests/test_selection_service.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 from traits.api import Any, Event, HasTraits, List, provides, Str

--- a/apptools/type_registry/__init__.py
+++ b/apptools/type_registry/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/type_registry/api.py
+++ b/apptools/type_registry/api.py
@@ -1,1 +1,10 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 from .type_registry import LazyRegistry, TypeRegistry

--- a/apptools/type_registry/tests/__init__.py
+++ b/apptools/type_registry/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/type_registry/tests/dummies.py
+++ b/apptools/type_registry/tests/dummies.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import abc
 
 

--- a/apptools/type_registry/tests/test_lazy_registry.py
+++ b/apptools/type_registry/tests/test_lazy_registry.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 from ..type_registry import LazyRegistry

--- a/apptools/type_registry/tests/test_type_registry.py
+++ b/apptools/type_registry/tests/test_type_registry.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 import unittest
 
 from ..type_registry import TypeRegistry

--- a/apptools/type_registry/type_registry.py
+++ b/apptools/type_registry/type_registry.py
@@ -1,3 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
 def get_mro(obj_class):
     """Get a reasonable method resolution order of a class and its
     superclasses for both old-style and new-style classes.

--- a/apptools/undo/__init__.py
+++ b/apptools/undo/__init__.py
@@ -1,13 +1,12 @@
-# Copyright (c) 2005-2011, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
+# Thanks for using Enthought open source!
 """ Supports undoing and scripting application commands.
     Part of the AppTools project of the Enthought Tool Suite.
 """

--- a/apptools/undo/action/__init__.py
+++ b/apptools/undo/action/__init__.py
@@ -1,10 +1,9 @@
-# Copyright (c) 2005-2011, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
+# Thanks for using Enthought open source!

--- a/apptools/undo/tests/__init__.py
+++ b/apptools/undo/tests/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!

--- a/apptools/undo/tests/test_command_stack.py
+++ b/apptools/undo/tests/test_command_stack.py
@@ -1,16 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2015, Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  This software is provided without warranty under the terms of the BSD
-#  license included in enthought/LICENSE.txt and may be redistributed only
-#  under the conditions described in the aforementioned license.  The license
-#  is also available online at http://www.enthought.com/licenses/BSD.txt
-#
-#  Thanks for using Enthought open source!
-#
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 from contextlib import contextmanager
 import unittest

--- a/apptools/undo/tests/testing_commands.py
+++ b/apptools/undo/tests/testing_commands.py
@@ -1,16 +1,12 @@
-# -----------------------------------------------------------------------------
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2015, Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  This software is provided without warranty under the terms of the BSD
-#  license included in enthought/LICENSE.txt and may be redistributed only
-#  under the conditions described in the aforementioned license.  The license
-#  is also available online at http://www.enthought.com/licenses/BSD.txt
-#
-#  Thanks for using Enthought open source!
-#
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 from traits.api import Int
 from apptools.undo.api import AbstractCommand

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # -*- coding: utf-8 -*-
 #
 # EnvisageCore documentation build configuration file, created by

--- a/etstool.py
+++ b/etstool.py
@@ -1,14 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2017, Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  This software is provided without warranty under the terms of the BSD
-#  license included in enthought/LICENSE.txt and may be redistributed only
-#  under the conditions described in the aforementioned license.  The license
-#  is also available online at http://www.enthought.com/licenses/BSD.txt
-#
-#  Thanks for using Enthought open source!
-#
+# Thanks for using Enthought open source!
 """
 Tasks for Test Runs
 ===================

--- a/etstool.py
+++ b/etstool.py
@@ -100,6 +100,7 @@ supported_runtimes = [
 
 dependencies = {
     "flake8",
+    "flake8_ets",
     "traitsui",
     "configobj",
     "coverage",

--- a/examples/naming/simple.py
+++ b/examples/naming/simple.py
@@ -1,16 +1,12 @@
-# -----------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
-# Description: <Enthought naming package component>
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 """ A simple naming example. """
 
 

--- a/examples/preferences/preferences_manager.py
+++ b/examples/preferences/preferences_manager.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 """ An example of using the preferences manager. """
 
 

--- a/examples/undo/commands.py
+++ b/examples/undo/commands.py
@@ -1,12 +1,16 @@
-# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# -----------------------------------------------------------------------------
+# Copyright (c) 2007, Riverbank Computing Limited
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only under
-# the conditions described in the aforementioned license. The license
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-#
 # Thanks for using Enthought open source!
+#
+# Author: Riverbank Computing Limited
+# Description: <Enthought undo package component>
+# -----------------------------------------------------------------------------
 
 
 # Enthought library imports.

--- a/examples/undo/commands.py
+++ b/examples/undo/commands.py
@@ -1,16 +1,12 @@
-# -----------------------------------------------------------------------------
-# Copyright (c) 2007, Riverbank Computing Limited
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Riverbank Computing Limited
-# Description: <Enthought undo package component>
-# -----------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 
 # Enthought library imports.

--- a/integrationtests/persistence/test_persistence.py
+++ b/integrationtests/persistence/test_persistence.py
@@ -1,3 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
 class Foo0:
     """ The original class written with no expectation of being upgraded """
     def __init__(self):

--- a/integrationtests/persistence/update1.py
+++ b/integrationtests/persistence/update1.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Update class names from the immediately prior version only
 # to ensure that cycles are not possible
 

--- a/integrationtests/persistence/update2.py
+++ b/integrationtests/persistence/update2.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Update class names from the immediately prior version only
 # to ensure that cycles are not possible
 

--- a/integrationtests/persistence/update3.py
+++ b/integrationtests/persistence/update3.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Update class names from the immediately prior version only
 # to ensure that cycles are not possible
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,10 @@
 [flake8]
 ignore = E266, W503
-per-file-ignores = */undo/*:H101, */api.py:F401, */__init__.py:F401,
-    apptools/undo/api.py:F401,H101, apptools/undo/action/api.py:F401,H101
+per-file-ignores = 
+    */api.py:F401,
+    */__init__.py:F401,
+    # ignore undo related errors because it has been copied to pyface and will
+    # soon be deprecated.  See enthought/apptools#243
+    */undo/*:H101,
+    apptools/undo/api.py:F401,H101,
+    apptools/undo/action/api.py:F401,H101

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 ignore = E266, W503
-per-file-ignores = */api.py:F401, */__init__.py:F401
+per-file-ignores = */undo/*:H101, */api.py:F401, */__init__.py:F401,
+    apptools/undo/api.py:F401,H101, apptools/undo/action/api.py:F401,H101


### PR DESCRIPTION
fixes #193 

This PR adds `flake8_ets` as a dependency so that copyright headers are checked by flake8, and also updates the copyright headers across apptools.

The only ones which may still need updating (they will currently cause flake8 errors which will cause the CI to fail on this PR) are some of those coming from `apptools.undo` which mention "Riverbank Computing Limited", e.g:
```
# ------------------------------------------------------------------------------
# Copyright (c) 2008, Riverbank Computing Limited
# All rights reserved.
#
# This software is provided without warranty under the terms of the BSD
# license included in enthought/LICENSE.txt and may be redistributed only
# under the conditions described in the aforementioned license.  The license
# is also available online at http://www.enthought.com/licenses/BSD.txt
# Thanks for using Enthought open source!
#
# Author: Riverbank Computing Limited
# Description: <Enthought undo package component>
# ------------------------------------------------------------------------------
```
I'm not sure what the correct way to handle these cases is. Maybe these should just be ignored in `setup.cfg`? (that would make the most sense to me)

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
