### PR TITLE
Fix deprecation warning from tests using TraitPrefixMap

### DIFF
--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -33,7 +33,7 @@ try:
     # Require Traits >= 6.1
     from traits.api import PrefixMap
 except ImportError:
-    from traits.api import Trait, TraitPrefixMap
+    from traits.api import TraitPrefixMap
     representation_trait = Trait(
         "surface", TraitPrefixMap({"surface": 2, "wireframe": 1, "points": 0})
     )

--- a/apptools/scripting/tests/test_recorder.py
+++ b/apptools/scripting/tests/test_recorder.py
@@ -23,12 +23,24 @@ from traits.api import (
     HasStrictTraits,
     Tuple,
     Range,
-    TraitPrefixMap,
     Trait,
 )
 from apptools.scripting.recorder import Recorder
 from apptools.scripting.recordable import recordable
 from apptools.scripting.package_globals import set_recorder
+
+try:
+    # Require Traits >= 6.1
+    from traits.api import PrefixMap
+except ImportError:
+    from traits.api import Trait, TraitPrefixMap
+    representation_trait = Trait(
+        "surface", TraitPrefixMap({"surface": 2, "wireframe": 1, "points": 0})
+    )
+else:
+    representation_trait = PrefixMap(
+        {"surface": 2, "wireframe": 1, "points": 0}, default_value="surface"
+    )
 
 
 ######################################################################
@@ -36,9 +48,7 @@ from apptools.scripting.package_globals import set_recorder
 class Property(HasStrictTraits):
     color = Tuple(Range(0.0, 1.0), Range(0.0, 1.0), Range(0.0, 1.0))
     opacity = Range(0.0, 1.0, 1.0)
-    representation = Trait(
-        "surface", TraitPrefixMap({"surface": 2, "wireframe": 1, "points": 0})
-    )
+    representation = representation_trait
 
 
 class Toy(HasTraits):


### PR DESCRIPTION
Closes #223

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Only concern warnings from tests, not news worthy
