### PR TITLE
Remove a redundant test

### DIFF
--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -288,36 +288,6 @@ class PreferencesHelperTestCase(unittest.TestCase):
         )
         self.assertEqual(new_preferences.keys("my_section"), ["list_of_str"])
 
-    def test_nested_container_mutation_not_supported(self):
-        """ Known limitation: mutation on nested containers are not
-        synchronized
-        See enthought/apptools#194
-        """
-
-        class MyPreferencesHelper(PreferencesHelper):
-            preferences_path = Str('my_section')
-            list_of_list_of_str = List(List(Str))
-
-        helper = MyPreferencesHelper(list_of_list_of_str=[["1"]])
-        helper.list_of_list_of_str[0].append("9")
-
-        self.preferences.save(self.tmpfile)
-
-        new_preferences = Preferences()
-        new_preferences.load(self.tmpfile)
-
-        # The event trait is not saved.
-        self.assertEqual(
-            new_preferences.keys("my_section"), ["list_of_list_of_str"]
-        )
-
-        # The values are not synchronized
-        with self.assertRaises(AssertionError):
-            self.assertEqual(
-                new_preferences.get("my_section.list_of_list_of_str"),
-                str(helper.list_of_list_of_str)
-            )
-
     def test_sync_anytrait_items_not_event(self):
         """ Test sychronizing trait with name *_items which is a normal trait
         rather than an event trait for listening to list/dict/set mutation.


### PR DESCRIPTION
This PR removes a test that demonstrates the (unexpected) behaviour noted in #194.

The test actually fails with Traits 6.0 because the particular setup of List of List happened to work there:
```
======================================================================
FAIL: test_nested_container_mutation_not_supported (apptools.preferences.tests.test_preferences_helper.PreferencesHelperTestCase)
Known limitation: mutation on nested containers are not
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/apptools/apptools/preferences/tests/test_preferences_helper.py", line 316, in test_nested_container_mutation_not_supported
    self.assertEqual(
AssertionError: AssertionError not raised
```

There is no much apptools can do to fix that. The test is closer to testing the limitations of Traits rather than testing Apptools itself, hence it should be removed. 

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~: The removed test had not been released in the past.
