### PR TITLE
Maint: Remove found news fragments rather than indiscriminately deleting all fragments in the folder

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -387,6 +387,9 @@ def build_changelog(ctx):
     # still require some tweaking.
     contents = []
 
+    # Collect news fragment files as we go, and then optionally remove them.
+    handled_file_paths = []
+
     for type_, description in ctx.obj["type_to_description"].items():
         pattern = os.path.join(NEWS_FRAGMENT_DIR, f"*.{type_}.rst")
         file_paths = sorted(glob.glob(pattern))
@@ -399,6 +402,7 @@ def build_changelog(ctx):
         for filename in file_paths:
             with open(filename, "r", encoding="utf-8") as fp:
                 contents.append("* " + fp.read())
+            handled_file_paths.append(filename)
 
     # Prepend content to the changelog file.
 
@@ -415,9 +419,8 @@ def build_changelog(ctx):
         "Do you want to remove the news fragments?"
     )
     if should_clean:
-        rmtree(NEWS_FRAGMENT_DIR)
-        os.makedirs(NEWS_FRAGMENT_DIR)
-
+        for file_path in handled_file_paths:
+            os.remove(file_path)
 
 # ----------------------------------------------------------------------------
 # Utility routines


### PR DESCRIPTION
This PR makes a change to the `python etstool.py changelog build` command such that only the found news fragment files are removed.

Motivation: If a news fragment file was misnamed, the build command won't collect its content. If the build command deletes the entire directory, such an omission will be harder to spot. By deleting only the found files, one can verify that the folder containing news fragments is indeed empty after build (with clean).

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ No change to developer workflow
