### PR TITLE
Remove use of TraitPrefixMap in documentation example

### DIFF
--- a/docs/releases/upcoming/247.doc.rst
+++ b/docs/releases/upcoming/247.doc.rst
@@ -1,0 +1,1 @@
+Replace TraitPrefixMap with PrefixMap in documentation example (#247)

--- a/docs/releases/upcoming/247.doc.rst
+++ b/docs/releases/upcoming/247.doc.rst
@@ -1,1 +1,0 @@
-Replace TraitPrefixMap with PrefixMap in documentation example (#247)

--- a/docs/source/scripting/introduction.rst
+++ b/docs/source/scripting/introduction.rst
@@ -44,7 +44,7 @@ The following example is taken from the test suite.  Consider a set of
 simple objects organized in a hierarchy::
 
     from traits.api import (HasTraits, Float, Instance,
-            Str, List, Bool, HasStrictTraits, Tuple, Range, TraitPrefixMap,
+            Str, List, Bool, HasStrictTraits, Tuple, PrefixMap, Range,
             Trait)
     from apptools.scripting.api import (Recorder, recordable,
         set_recorder)
@@ -52,10 +52,11 @@ simple objects organized in a hierarchy::
     class Property(HasStrictTraits):
         color = Tuple(Range(0.0, 1.0), Range(0.0, 1.0), Range(0.0, 1.0))
         opacity = Range(0.0, 1.0, 1.0)
-        representation = Trait('surface',
-                               TraitPrefixMap({'surface':2,
-                                               'wireframe': 1,
-                                               'points': 0}))
+        representation = PrefixMap(
+            {"surface": 2, "wireframe": 1, "points": 0},
+            default_value="surface"
+        )
+
     class Toy(HasTraits):
         color = Str
         type = Str


### PR DESCRIPTION
This PR updates documentation to remove usage of `TraitPrefixMap` which has been deprecated since Traits 6.1.

The example is the same as the one #244 modified in tests. Since this is for documentation, I think we can assume latest Traits version and there are no need to rewrite a compatibility layer there.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ (edited: Too minor)
