### PR TITLE
fix a few broken links in documentation

### DIFF
--- a/docs/releases/upcoming/248.doc.rst
+++ b/docs/releases/upcoming/248.doc.rst
@@ -1,0 +1,1 @@
+Fix a few broken links in the documentation (#248)

--- a/docs/source/preferences/PreferencesInEnvisage.rst
+++ b/docs/source/preferences/PreferencesInEnvisage.rst
@@ -7,7 +7,7 @@ This section discusses how an Envisage application uses the preferences
 mechanism. Envisage tries not to dictate too much, and so this describes the
 default behaviour, but you are free to override it as desired.
 
-Envisage uses the default implementation of the ScopedPreferences_ class which
+Envisage uses the default implementation of the |ScopedPreferences| class which
 is made available via the application's 'preferences' trait::
 
   >>> application = Application(id='myapplication')
@@ -19,7 +19,7 @@ Hence, you use the Envisage preferences just like you would any other scoped
 preferences.
 
 It also registers itself as the default preferences node used by the
-PreferencesHelper_ class. Hence you don't need to provide a preferences node
+|PreferencesHelper| class. Hence you don't need to provide a preferences node
 explicitly to your helper::
 
   >>> helper = SplashScreenPreferences()
@@ -45,5 +45,8 @@ e.g. To contribute a preference file for my plugin I might use::
       def get_preferences(self, application):
           return ['pkgfile://mypackage:preferences.ini']
 
-.. _PreferencesHelper: ../../enthought/preferences/preferences_helper.py
-.. _ScopedPreferences: ../../enthought/preferences/scoped_preferences.py
+..
+   # substitutions
+
+.. |PreferencesHelper| replace:: :class:`~apptools.preferences.preferences_helper.PreferencesHelper`
+.. |ScopedPreferences| replace:: :class:`~apptools.preferences.scoped_preferences.ScopedPreferences`

--- a/docs/source/scripting/introduction.rst
+++ b/docs/source/scripting/introduction.rst
@@ -16,8 +16,8 @@ This package is not just a toy framework and is powerful enough to
 provide full script recording to the Mayavi_ application.  Mayavi is a
 powerful 3D visualization tool that is part of ETS_.
 
-.. _Mayavi: http://code.enthought.com/projects/mayavi
-.. _ETS: http://code.enthought.com/projects/tool-suite.php
+.. _Mayavi: https://docs.enthought.com/mayavi/mayavi/
+.. _ETS: https://docs.enthought.com/ets/
 
 .. _scripting-api:
 


### PR DESCRIPTION
fixes #171 

Note when writing issue 171 I noticed the broken links on https://docs.enthought.com/apptools/.  I had not built the documentation from master, and after doing so it seems that the majority of the links were working on master.  I went through and checked links from the docs built on master and those that were still broken I have fixed here (only a few).

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
