### PR TITLE
add news fragment for apptools.undo deprecation

### DIFF
--- a/docs/releases/upcoming/250.deprecation.rst
+++ b/docs/releases/upcoming/250.deprecation.rst
@@ -1,1 +1,1 @@
-Deprecatee apptools.undo subpackage (undo was moved to pyface) (#250)
+Deprecate apptools.undo subpackage (undo was moved to pyface) (#250)

--- a/docs/releases/upcoming/250.deprecation.rst
+++ b/docs/releases/upcoming/250.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecatee apptools.undo subpackage (undo was moved to pyface) (#250)


### PR DESCRIPTION
PR #250 was merged without a news fragment, but it needs one.  This PR simply adds that news fragment.

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
