### PR TITLE
Add extras_require to setup.py for optional dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,9 @@ The `apptools.preferences` package requires:
 
 * `configobj <http://pypi.python.org/pypi/configobj>`_
 
-To install with `apptools.preferences` dependencies:
-`$ pip install apptools[preferences]`
+To install with `apptools.preferences` dependencies::
+
+    `$ pip install apptools[preferences]`
 
 The `apptools.io.h5` package requires:
 
@@ -53,15 +54,21 @@ The `apptools.io.h5` package requires:
 * `pandas <https://pypi.org/project/pandas/>`_
 * `tables <https://pypi.org/project/tables/>`_
 
-To install with `apptools.io.h5` dependencies:
-`$ pip install apptools[h5]`
+To install with `apptools.io.h5` dependencies::
+
+    `$ pip install apptools[h5]`
 
 The `apptools.persistence` package requires:
 
 * `numpy <https://pypi.org/project/numpy/>`_
 
-To install with `apptools.persistence` dependencies:
-`$ pip install apptools[persistence]`
+To install with `apptools.persistence` dependencies::
+
+    `$ pip install apptools[persistence]`
+
+To install with additional test dependencies::
+
+    $ pip install apptools[test]
 
 Many of the packages provide optional user interfaces using Pyface and
 Traitsui. In additon, many of the packages are designed to work with the

--- a/README.rst
+++ b/README.rst
@@ -44,31 +44,15 @@ The `apptools.preferences` package requires:
 
 * `configobj <http://pypi.python.org/pypi/configobj>`_
 
-To install with `apptools.preferences` dependencies::
-
-    $ pip install apptools[preferences]
-
 The `apptools.io.h5` package requires:
 
 * `numpy <https://pypi.org/project/numpy/>`_
 * `pandas <https://pypi.org/project/pandas/>`_
 * `tables <https://pypi.org/project/tables/>`_
 
-To install with `apptools.io.h5` dependencies::
-
-    $ pip install apptools[h5]
-
 The `apptools.persistence` package requires:
 
 * `numpy <https://pypi.org/project/numpy/>`_
-
-To install with `apptools.persistence` dependencies::
-
-    $ pip install apptools[persistence]
-
-To install with additional test dependencies::
-
-    $ pip install apptools[test]
 
 Many of the packages provide optional user interfaces using Pyface and
 Traitsui. In additon, many of the packages are designed to work with the
@@ -77,3 +61,22 @@ Envisage plug-in system, althought most can be used independently:
 * `envisage <https://github.com/enthought/envisage>`_
 * `pyface <https://github.com/enthought/pyface>`_
 * `traitsui <https://github.com/enthought/traitsui>`_
+
+Installation
+------------
+
+To install with `apptools.preferences` dependencies::
+
+    $ pip install apptools[preferences]
+
+To install with `apptools.io.h5` dependencies::
+
+    $ pip install apptools[h5]
+
+To install with `apptools.persistence` dependencies::
+
+    $ pip install apptools[persistence]
+
+To install with additional test dependencies::
+
+    $ pip install apptools[test]

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ The `apptools.preferences` package requires:
 
 To install with `apptools.preferences` dependencies::
 
-    `$ pip install apptools[preferences]`
+    $ pip install apptools[preferences]
 
 The `apptools.io.h5` package requires:
 
@@ -56,7 +56,7 @@ The `apptools.io.h5` package requires:
 
 To install with `apptools.io.h5` dependencies::
 
-    `$ pip install apptools[h5]`
+    $ pip install apptools[h5]
 
 The `apptools.persistence` package requires:
 
@@ -64,7 +64,7 @@ The `apptools.persistence` package requires:
 
 To install with `apptools.persistence` dependencies::
 
-    `$ pip install apptools[persistence]`
+    $ pip install apptools[persistence]
 
 To install with additional test dependencies::
 

--- a/README.rst
+++ b/README.rst
@@ -44,15 +44,24 @@ The `apptools.preferences` package requires:
 
 * `configobj <http://pypi.python.org/pypi/configobj>`_
 
+To install with `apptools.preferences` dependencies:
+`$ pip install apptools[preferences]`
+
 The `apptools.io.h5` package requires:
 
 * `numpy <https://pypi.org/project/numpy/>`_
 * `pandas <https://pypi.org/project/pandas/>`_
 * `tables <https://pypi.org/project/tables/>`_
 
+To install with `apptools.io.h5` dependencies:
+`$ pip install apptools[h5]`
+
 The `apptools.persistence` package requires:
 
 * `numpy <https://pypi.org/project/numpy/>`_
+
+To install with `apptools.persistence` dependencies:
+`$ pip install apptools[persistence]`
 
 Many of the packages provide optional user interfaces using Pyface and
 Traitsui. In additon, many of the packages are designed to work with the

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,22 @@ All packages in apptools require:
 
 * `traits <https://github.com/enthought/traits>`_
 
+Certain sub-packages within apptools have their own specific dependencies,
+which are optional for apptools overall.
+
 The `apptools.preferences` package requires:
 
 * `configobj <http://pypi.python.org/pypi/configobj>`_
+
+The `apptools.io.h5` package requires:
+
+* `numpy <https://pypi.org/project/numpy/>`_
+* `pandas <https://pypi.org/project/pandas/>`_
+* `tables <https://pypi.org/project/tables/>`_
+
+The `apptools.persistence` package requires:
+
+* `numpy <https://pypi.org/project/numpy/>`_
 
 Many of the packages provide optional user interfaces using Pyface and
 Traitsui. In additon, many of the packages are designed to work with the

--- a/apptools/logger/log_point.py
+++ b/apptools/logger/log_point.py
@@ -15,8 +15,6 @@
 
 # Standard library imports.
 import inspect
-
-# Third-party library imports.
 from io import StringIO
 
 

--- a/apptools/logger/plugin/logger_service.py
+++ b/apptools/logger/plugin/logger_service.py
@@ -8,12 +8,10 @@
 #
 # Thanks for using Enthought open source!
 # Standard library imports
+from io import BytesIO
 import logging
 import os
 import zipfile
-
-# Third-party library imports
-from io import BytesIO
 
 # Enthought library imports
 from pyface.workbench.api import View as WorkbenchView

--- a/docs/releases/upcoming/257.build.rst
+++ b/docs/releases/upcoming/257.build.rst
@@ -1,0 +1,1 @@
+Add extras_require to setup.py for optional dependencies

--- a/docs/releases/upcoming/257.build.rst
+++ b/docs/releases/upcoming/257.build.rst
@@ -1,1 +1,1 @@
-Add extras_require to setup.py for optional dependencies
+Add extras_require to setup.py for optional dependencies (#257)

--- a/setup.py
+++ b/setup.py
@@ -318,6 +318,9 @@ if __name__ == "__main__":
             "persistence": [
                 "numpy",
             ],
+            "preferences": [
+                "configobj",
+            ],
         },
         license='BSD',
         packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -310,6 +310,14 @@ if __name__ == "__main__":
             "test": [
                 "importlib-resources>=1.1.0",
             ],
+            "h5": [
+                "numpy",
+                "pandas",
+                "tables",
+            ],
+            "persistence": [
+                "numpy",
+            ],
         },
         license='BSD',
         packages=find_packages(),


### PR DESCRIPTION
fixes #176 

This PR adds to the `extras_require` section in `setup.py` to include additional optional dependencies.  It also mentions these in the readme so they are more apparent (Should I add instructions saying to run `pip install apptools[h5]` for examples?  I thought that might be overkill, but was unsure).

Note in this PR when looking for any optional dependencies I saw `io` imports listed as third party imports, so I moved those to be with standard library imports 

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
