### PR TITLE
Set IS_RELEASED back to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 5
 MINOR = 0
 MICRO = 0
 PRERELEASE = "rc1"
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR simply sets `IS_RELEASED` back to False.

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
