### PR TITLE
Make sure optional dependencies are optional for tests

### DIFF
--- a/apptools/io/h5/tests/test_dict_node.py
+++ b/apptools/io/h5/tests/test_dict_node.py
@@ -9,16 +9,23 @@
 # Thanks for using Enthought open source!
 import unittest
 
-import numpy as np
-from numpy.testing import assert_allclose
+from apptools._testing.optional_dependencies import (
+    numpy as np,
+    tables,
+    requires_numpy,
+    requires_tables,
+)
 
-from ..dict_node import H5DictNode
-from .utils import open_h5file, temp_h5_file, temp_file
+if np is not None and tables is not None:
+    from ..dict_node import H5DictNode
+    from .utils import open_h5file, temp_h5_file, temp_file
 
 
 NODE = "/dict_node"
 
 
+@requires_tables
+@requires_numpy
 class DictNodeTestCase(unittest.TestCase):
     def test_create(self):
         with temp_h5_file() as h5:
@@ -56,8 +63,8 @@ class DictNodeTestCase(unittest.TestCase):
 
             h5dict = H5DictNode.add_to_h5file(h5, NODE, data)
             assert h5dict["a"] == 10
-            assert_allclose(h5dict["foo"], foo)
-            assert_allclose(h5dict["bar"], bar)
+            np.testing.assert_allclose(h5dict["foo"], foo)
+            np.testing.assert_allclose(h5dict["bar"], bar)
 
     def test_load_saved_dict_node(self):
         with temp_file() as filename:
@@ -91,7 +98,7 @@ class DictNodeTestCase(unittest.TestCase):
             # Read dict node and make sure the data was saved.
             with open_h5file(filename, mode="r+") as h5:
                 h5dict = h5[NODE]
-                assert_allclose(h5dict["arr"], arr)
+                np.testing.assert_allclose(h5dict["arr"], arr)
                 # Change data for next test
                 h5dict["arr"] = arr1
                 h5dict["arr_old"] = arr
@@ -99,8 +106,8 @@ class DictNodeTestCase(unittest.TestCase):
             # Check that data is modified by the previous write.
             with open_h5file(filename) as h5:
                 h5dict = h5[NODE]
-                assert_allclose(h5dict["arr"], arr1)
-                assert_allclose(h5dict["arr_old"], arr)
+                np.testing.assert_allclose(h5dict["arr"], arr1)
+                np.testing.assert_allclose(h5dict["arr_old"], arr)
                 # Make sure that arrays come back as arrays
                 assert isinstance(h5dict["arr"], np.ndarray)
                 assert isinstance(h5dict["arr_old"], np.ndarray)

--- a/apptools/persistence/tests/test_file_path.py
+++ b/apptools/persistence/tests/test_file_path.py
@@ -21,16 +21,24 @@ from io import BytesIO
 # 3rd party imports.
 from importlib_resources import files
 
+from apptools._testing.optional_dependencies import (
+    numpy as np,
+    requires_numpy,
+)
+
 # Enthought library imports.
-from apptools.persistence import state_pickler
-from apptools.persistence import file_path
+if np is not None:
+    from apptools.persistence import state_pickler
+    from apptools.persistence import file_path
 
 
+@requires_numpy
 class Test:
     def __init__(self):
         self.f = file_path.FilePath()
 
 
+@requires_numpy
 class TestFilePath(unittest.TestCase):
     def setUp(self):
         # If the cwd is somewhere under /tmp, that confuses the tests below.

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -19,10 +19,10 @@ import math
 import os
 import tempfile
 
-from apptools._testing.optional_dependencies import (
-    numpy,
-    requires_numpy,
-)
+try:
+    import numpy
+except ImportError:
+    raise unittest.SkipTest("Can't import NumPy: skipping")
 
 from traits.api import (
     Bool,
@@ -46,68 +46,70 @@ except ImportError:
 else:
     TVTK_AVAILABLE = True
 
-if numpy is not None:
-    from apptools.persistence import state_pickler
+from apptools.persistence import state_pickler
 
-    # A simple class to test instances.
-    class A(object):
 
-        def __init__(self):
-            self.a = "a"
+# A simple class to test instances.
+class A(object):
 
-    # NOTE: I think that TVTK specific testing should be moved to the
-    #       TVTK package.
+    def __init__(self):
+        self.a = "a"
 
-    # A classic class for testing the pickler.
-    class TestClassic:
-        def __init__(self):
-            self.b = False
-            self.i = 7
-            self.longi = 1234567890123456789
-            self.f = math.pi
-            self.c = complex(1.01234, 2.3)
-            self.n = None
-            self.s = "String"
-            self.u = "Unicode"
-            self.inst = A()
-            self.tuple = (1, 2, "a", A())
-            self.list = [1, 1.1, "a", 1j, self.inst]
-            self.pure_list = list(range(5))
-            self.dict = {"a": 1, "b": 2, "ref": self.inst}
-            self.numeric = numpy.ones((2, 2, 2), "f")
-            self.ref = self.numeric
-            if TVTK_AVAILABLE:
-                self._tvtk = tvtk.Property()
 
-    # A class with traits for testing the pickler.
-    class TestTraits(HasTraits):
-        b = Bool(False)
-        i = Int(7)
-        longi = Int(12345678901234567890)
-        f = Float(math.pi)
-        c = Complex(complex(1.01234, 2.3))
-        n = Any
-        s = Str("String")
-        u = Str("Unicode")
-        inst = Instance(A)
-        tuple = Tuple
-        list = List
-        pure_list = List(list(range(5)))
-        dict = Dict
-        numeric = Array(value=numpy.ones((2, 2, 2), "f"))
-        ref = Array
+# NOTE: I think that TVTK specific testing should be moved to the
+#       TVTK package.
+
+
+# A classic class for testing the pickler.
+class TestClassic:
+    def __init__(self):
+        self.b = False
+        self.i = 7
+        self.longi = 1234567890123456789
+        self.f = math.pi
+        self.c = complex(1.01234, 2.3)
+        self.n = None
+        self.s = "String"
+        self.u = "Unicode"
+        self.inst = A()
+        self.tuple = (1, 2, "a", A())
+        self.list = [1, 1.1, "a", 1j, self.inst]
+        self.pure_list = list(range(5))
+        self.dict = {"a": 1, "b": 2, "ref": self.inst}
+        self.numeric = numpy.ones((2, 2, 2), "f")
+        self.ref = self.numeric
         if TVTK_AVAILABLE:
-            _tvtk = Instance(tvtk.Property, ())
-
-        def __init__(self):
-            self.inst = A()
-            self.tuple = (1, 2, "a", A())
-            self.list = [1, 1.1, "a", 1j, self.inst]
-            self.dict = {"a": 1, "b": 2, "ref": self.inst}
-            self.ref = self.numeric
+            self._tvtk = tvtk.Property()
 
 
-@requires_numpy
+# A class with traits for testing the pickler.
+class TestTraits(HasTraits):
+    b = Bool(False)
+    i = Int(7)
+    longi = Int(12345678901234567890)
+    f = Float(math.pi)
+    c = Complex(complex(1.01234, 2.3))
+    n = Any
+    s = Str("String")
+    u = Str("Unicode")
+    inst = Instance(A)
+    tuple = Tuple
+    list = List
+    pure_list = List(list(range(5)))
+    dict = Dict
+    numeric = Array(value=numpy.ones((2, 2, 2), "f"))
+    ref = Array
+    if TVTK_AVAILABLE:
+        _tvtk = Instance(tvtk.Property, ())
+
+    def __init__(self):
+        self.inst = A()
+        self.tuple = (1, 2, "a", A())
+        self.list = [1, 1.1, "a", 1j, self.inst]
+        self.dict = {"a": 1, "b": 2, "ref": self.inst}
+        self.ref = self.numeric
+
+
 class TestDictPickler(unittest.TestCase):
     def set_object(self, obj):
         """Changes the objects properties to test things."""

--- a/apptools/persistence/tests/test_version_registry.py
+++ b/apptools/persistence/tests/test_version_registry.py
@@ -19,7 +19,12 @@ import unittest
 # Enthought library imports.
 from traits.api import HasTraits
 
-from apptools.persistence import version_registry, state_pickler
+from apptools._testing.optional_dependencies import (
+    numpy as np,
+    requires_numpy,
+)
+if np is not None:
+    from apptools.persistence import version_registry, state_pickler
 
 
 class Classic:
@@ -52,6 +57,7 @@ class Handler:
         self.calls.append(("upgrade1", state, version))
 
 
+@requires_numpy
 class TestVersionRegistry(unittest.TestCase):
     def test_get_version(self):
         """Test the get_version function."""

--- a/apptools/selection/tests/test_list_selection.py
+++ b/apptools/selection/tests/test_list_selection.py
@@ -9,11 +9,16 @@
 # Thanks for using Enthought open source!
 import unittest
 
-import numpy
+from apptools._testing.optional_dependencies import (
+    numpy,
+    requires_numpy,
+)
 
-from apptools.selection.api import ListSelection
+if numpy is not None:
+    from apptools.selection.api import ListSelection
 
 
+@requires_numpy
 class TestListSelection(unittest.TestCase):
     def test_list_selection(self):
         all_items = ["a", "b", "c", "d"]

--- a/docs/releases/upcoming/260.test.rst
+++ b/docs/releases/upcoming/260.test.rst
@@ -1,0 +1,1 @@
+Make optional dependencies optional for tests (#260)


### PR DESCRIPTION
fixes #99 

This PR uses the existing `apptools._testing.optional_dependencies` to ensure that optional dependencies are optional for tests.  The test suite should no longer fail if certain optional dependencies are not installed.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
