### PR TITLE
Add a new category for build system related changes

### DIFF
--- a/docs/releases/README.rst
+++ b/docs/releases/README.rst
@@ -14,6 +14,7 @@ Create a new file with a name like ``<pull-request>.<type>.rst``, where
 - ``removal``: Removal of public API
 - ``doc``: Documentation changes
 - ``test``: Changes to test suite ('end users' are distribution packagers)
+- ``build``: Build system changes that affect how the distribution is installed
 
 Then write a short sentence in the file that describes the changes for the
 end users, e.g. in ``123.removal.rst``::

--- a/etstool.py
+++ b/etstool.py
@@ -342,6 +342,7 @@ def changelog(ctx):
             "removal": "Removals",
             "doc": "Documentation changes",
             "test": "Test suite",
+            "build": "Build System",
         }
     }
 


### PR DESCRIPTION
Motivated by #257

This PR adds a new category for the news fragments containing build system related changes. 

**Checklist**
- ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~

