### PR TITLE
Bump release version for the development of 5.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 5
 MINOR = 0
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
[targeting maint/5.0]

This PR bumps the release version and flips the IS_RELEASE flag for the development of the next bug fix release.

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
