### PR TITLE
Correct RedoAction/UndoAction imports from pyface

### DIFF
--- a/apptools/undo/action/api.py
+++ b/apptools/undo/action/api.py
@@ -12,7 +12,7 @@
 # Description: <Enthought undo package component>
 # ------------------------------------------------------------------------------
 
-from pyface.undo.action.command_action import (
+from pyface.undo.action.api import (
     CommandAction,
     RedoAction,
     UndoAction,


### PR DESCRIPTION
This fixes an issue introduced in the PR #272 - `apptools.undo.action.api` tries importing `RedoAction`/`UndoAction` from `pyface.undo.action.command_action` - which is not the right thing to do. This import has been updated to use `pyface.undo.action.api` instead.

This also fixes an new sphinx warning introduced in #272 

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
