### PR TITLE
Bump version for continued development (5.2.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 # together with information from the version control system, and then injected
 # into the package source.
 MAJOR = 5
-MINOR = 1
+MINOR = 2
 MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = False


### PR DESCRIPTION
This PR simply bumps the version number in setup.py for continued development in advance of the 5.1.0 minor release.

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
