### PR TITLE
update changelog for 5.1.0 release and remove news fragment files

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Version 5.1.0
 
 Released : 2021-01-13
 
+This is a minor release in which the modules in the apptools.undo subpackage are
+modified to import from pyface.undo rather than redefining the classes.  This
+should help ease the transition to using pyface.undo in place of the now
+deprecated apptool.undo.
+
 Deprecations
 ------------
 * Import from pyface.undo.* instead of redefining classes in apptools.undo.* (#272)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,19 @@
 Apptools CHANGELOG
 ==================
 
+Version 5.1.0
+~~~~~~~~~~~~~
+
+Released : 2021-01-13
+
+Deprecations
+------------
+* Import from pyface.undo.* instead of redefining classes in apptools.undo.* (#272)
+
+Documentation changes
+---------------------
+* Add module docstrings to the various api modules in apptools subpackages (#274)
+
 Version 5.0.0
 ~~~~~~~~~~~~~
 

--- a/docs/releases/upcoming/116.bugfix.rst
+++ b/docs/releases/upcoming/116.bugfix.rst
@@ -1,1 +1,0 @@
-Fix SyntaxWarning in persistence.file_path (#116)

--- a/docs/releases/upcoming/172.removal.rst
+++ b/docs/releases/upcoming/172.removal.rst
@@ -1,1 +1,0 @@
-Remove ``appscripting`` subpackage (#172)

--- a/docs/releases/upcoming/173.removal.rst
+++ b/docs/releases/upcoming/173.removal.rst
@@ -1,1 +1,0 @@
-Remove ``template`` subpackage (#173)

--- a/docs/releases/upcoming/175.removal.rst
+++ b/docs/releases/upcoming/175.removal.rst
@@ -1,1 +1,0 @@
-Remove ``permission`` subpackage (#175)

--- a/docs/releases/upcoming/184.removal.rst
+++ b/docs/releases/upcoming/184.removal.rst
@@ -1,1 +1,0 @@
-Remove ``lru_cache`` subpackage (#184)

--- a/docs/releases/upcoming/190.removal.rst
+++ b/docs/releases/upcoming/190.removal.rst
@@ -1,1 +1,0 @@
-Remove support for Python 2.7 and 3.5 (#190)

--- a/docs/releases/upcoming/196.bugfix.rst
+++ b/docs/releases/upcoming/196.bugfix.rst
@@ -1,1 +1,0 @@
-Fix container items change event being saved in preferences (#196)

--- a/docs/releases/upcoming/198.doc.rst
+++ b/docs/releases/upcoming/198.doc.rst
@@ -1,1 +1,0 @@
-Update documentation for Preferences (#198)

--- a/docs/releases/upcoming/199.removal.rst
+++ b/docs/releases/upcoming/199.removal.rst
@@ -1,4 +1,0 @@
-remove the ``apptools.sweet_pickle`` subpackage.  Note that users of
-sweet_pickle can in some cases transition to using ``apptools.persistence`` and
-pickle from the python standard library (see changes made in this PR to
-``apptools.naming`` for more info) (#199)

--- a/docs/releases/upcoming/210.test.rst
+++ b/docs/releases/upcoming/210.test.rst
@@ -1,1 +1,0 @@
-Fix AttributeError on Python 3.9 due to usage of ``base64.decodestring`` in tests (#210)

--- a/docs/releases/upcoming/215.removal.rst
+++ b/docs/releases/upcoming/215.removal.rst
@@ -1,1 +1,0 @@
-Remove ``help`` subpackage (#215)

--- a/docs/releases/upcoming/216.removal.rst
+++ b/docs/releases/upcoming/216.removal.rst
@@ -1,1 +1,0 @@
-remove NullHandler from ``apptools.logger`` (#216)

--- a/docs/releases/upcoming/217.removal.rst
+++ b/docs/releases/upcoming/217.removal.rst
@@ -1,1 +1,0 @@
-Remove ``apptools.logger.filtering_handler`` and ``apptools.logger.util`` submodules (#217)

--- a/docs/releases/upcoming/218.removal.rst
+++ b/docs/releases/upcoming/218.removal.rst
@@ -1,1 +1,0 @@
-Remove deprecated create_log_file_handler function (#218)

--- a/docs/releases/upcoming/219.removal.rst
+++ b/docs/releases/upcoming/219.removal.rst
@@ -1,1 +1,0 @@
-Remove use of ``apptools.type_manage`r`` from ``apptools.naming``.  Then, remove ``apptools.type_manager`` entirely.  Finally, remove ``apptools.naming.adapter``. (#219)

--- a/docs/releases/upcoming/220.removal.rst
+++ b/docs/releases/upcoming/220.removal.rst
@@ -1,1 +1,0 @@
-Remove ``apptools.persistence.spickle.py`` submodule (#220)

--- a/docs/releases/upcoming/221.doc.rst
+++ b/docs/releases/upcoming/221.doc.rst
@@ -1,1 +1,0 @@
-Add a brief section to documentation for ``apptools.naming`` (#221)

--- a/docs/releases/upcoming/226.bugfix.rst
+++ b/docs/releases/upcoming/226.bugfix.rst
@@ -1,1 +1,0 @@
-Fix synchronizing preference trait with name *_items (#226)

--- a/docs/releases/upcoming/233.removal.rst
+++ b/docs/releases/upcoming/233.removal.rst
@@ -1,1 +1,0 @@
-Remove ``apptools.naming.ui`` sub package (#233)

--- a/docs/releases/upcoming/237.doc.rst
+++ b/docs/releases/upcoming/237.doc.rst
@@ -1,1 +1,0 @@
-Document the ``apptools.io`` and ``apptools.io.h5`` sub packages (#237)

--- a/docs/releases/upcoming/248.doc.rst
+++ b/docs/releases/upcoming/248.doc.rst
@@ -1,1 +1,0 @@
-Fix a few broken links in the documentation (#248)

--- a/docs/releases/upcoming/250.deprecation.rst
+++ b/docs/releases/upcoming/250.deprecation.rst
@@ -1,1 +1,0 @@
-Deprecate apptools.undo subpackage (undo was moved to pyface) (#250)

--- a/docs/releases/upcoming/257.build.rst
+++ b/docs/releases/upcoming/257.build.rst
@@ -1,1 +1,0 @@
-Add extras_require to setup.py for optional dependencies (#257)

--- a/docs/releases/upcoming/260.test.rst
+++ b/docs/releases/upcoming/260.test.rst
@@ -1,1 +1,0 @@
-Make optional dependencies optional for tests (#260)

--- a/docs/releases/upcoming/272.deprecation.rst
+++ b/docs/releases/upcoming/272.deprecation.rst
@@ -1,1 +1,0 @@
-Import from pyface.undo.* instead of redefining classes in apptools.undo.* (#272)

--- a/docs/releases/upcoming/274.doc.rst
+++ b/docs/releases/upcoming/274.doc.rst
@@ -1,1 +1,0 @@
-Add module docstrings to the various api modules in apptools subpackages (#274)


### PR DESCRIPTION
[Targeting maint/5.1]

This PR simply updates the changelog for the 5.1.0 release (by using the python etstool.py changelog build command). In doing so it deletes all of the news fragments files. Further in adds a release description in the changelog

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
