### PR TITLE
Mention Undo is deprecated in docs

### DIFF
--- a/docs/source/undo/Introduction.rst
+++ b/docs/source/undo/Introduction.rst
@@ -2,7 +2,7 @@ Undo Framework
 ==============
 
 .. warning:: 
-    apptools.undo has been deprecated and moved to sit in
+    apptools.undo has been deprecated and moved to
     `Pyface <https://github.com/enthought/pyface>`_. It will be removed in a
     future release. Please use `pyface.undo <https://docs.enthought.com/pyface/undo.html>`_
     instead.

--- a/docs/source/undo/Introduction.rst
+++ b/docs/source/undo/Introduction.rst
@@ -1,6 +1,12 @@
 Undo Framework
 ==============
 
+.. warning:: 
+    apptools.undo has been deprecated and moved to sit in
+    `Pyface <https://github.com/enthought/pyface>`_. It will be removed in a
+    future release. Please use `pyface.undo <https://docs.enthought.com/pyface/undo.html>`_
+    instead.
+
 The Undo Framework is a component of the Enthought Tool Suite that provides
 developers with an API that implements the standard pattern for do/undo/redo
 commands.


### PR DESCRIPTION
This PR adds a warning to the Undo section of the documentation about the deprecation and refers to pyface.undo
**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
This PR does not need a news fragment as the deprecation has already been documented in the changelog.


This PR needs to be backported to maint/5.1