### PR TITLE
python39: importlib_resources -> importlib.resources

### DIFF
--- a/apptools/persistence/tests/test_file_path.py
+++ b/apptools/persistence/tests/test_file_path.py
@@ -19,7 +19,10 @@ from os.path import abspath, dirname, basename, join
 from io import BytesIO
 
 # 3rd party imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 from apptools._testing.optional_dependencies import (
     numpy as np,

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -17,7 +17,10 @@ import unittest
 from os.path import join
 
 # Major package imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -17,7 +17,10 @@ import unittest
 from os.path import join
 
 # Major package imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -17,7 +17,10 @@ import tempfile
 import unittest
 
 # Major package imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences, PreferencesHelper

--- a/apptools/preferences/tests/test_py_config_file.py
+++ b/apptools/preferences/tests/test_py_config_file.py
@@ -17,7 +17,10 @@ import unittest
 from os.path import join
 
 # Major package imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from .py_config_file import PyConfigFile

--- a/apptools/preferences/tests/test_scoped_preferences.py
+++ b/apptools/preferences/tests/test_scoped_preferences.py
@@ -16,7 +16,10 @@ import tempfile
 from os.path import join
 
 # Major package imports.
-from importlib_resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from apptools.preferences.api import Preferences, ScopedPreferences

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
         ],
         extras_require={
             "test": [
-                "importlib-resources>=1.1.0",
+                "importlib-resources>=1.1.0; python_version<'3.9'",
             ],
             "h5": [
                 "numpy",


### PR DESCRIPTION
Because `importlib_resources` is the backport of `importlib.resources`, the standard lib module should be preferred if it is available.