### PR TITLE
Replace on_trait_change with observe

### DIFF
--- a/apptools/logger/plugin/logger_service.py
+++ b/apptools/logger/plugin/logger_service.py
@@ -171,7 +171,7 @@ class LoggerService(HasTraits):
         )
 
     @observe("preferences.level_")
-    def _level_changed(self, event):
+    def _use_updated_preferences_level(self, event):
         new = event.new
         if (
             new is not None

--- a/apptools/logger/plugin/logger_service.py
+++ b/apptools/logger/plugin/logger_service.py
@@ -23,7 +23,7 @@ from traits.api import (
     List,
     Property,
     Undefined,
-    on_trait_change,
+    observe,
 )
 
 root_logger = logging.getLogger()
@@ -170,8 +170,9 @@ class LoggerService(HasTraits):
             "apptools.logger.plugin.mail_files"
         )
 
-    @on_trait_change("preferences.level_")
-    def _level_changed(self, new):
+    @observe("preferences.level_")
+    def _level_changed(self, event):
+        new = event.new
         if (
             new is not None
             and new is not Undefined

--- a/apptools/logger/plugin/view/logger_view.py
+++ b/apptools/logger/plugin/view/logger_view.py
@@ -22,7 +22,7 @@ from traits.api import (
     Property,
     Str,
     cached_property,
-    on_trait_change,
+    observe,
 )
 from traitsui.api import View, Group, Item, CodeEditor, TabularEditor, spring
 from traitsui.tabular_adapter import TabularAdapter
@@ -144,8 +144,8 @@ class LoggerView(TraitsUIView):
     # Private interface
     ###########################################################################
 
-    @on_trait_change("service.preferences.level_")
-    def _update_log_records(self):
+    @observe("service.preferences.level_")
+    def _update_log_records(self, event):
         self.service.handler._view = self
         self.update(force=True)
 

--- a/apptools/preferences/preference_binding.py
+++ b/apptools/preferences/preference_binding.py
@@ -69,10 +69,10 @@ class PreferenceBinding(HasTraits):
 
     #### Trait change handlers ################################################
 
-    def _on_trait_changed(self, obj, trait_name, old, new):
+    def _on_trait_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.preferences.set(self.preference_path, new)
+        self.preferences.set(self.preference_path, event.new)
 
     #### Other observer pattern listeners #####################################
 
@@ -121,7 +121,7 @@ class PreferenceBinding(HasTraits):
         """ Wire-up trait change handlers etc. """
 
         # Listen for the object's trait being changed.
-        self.obj.on_trait_change(self._on_trait_changed, self.trait_name)
+        self.obj.observe(self._on_trait_changed, self.trait_name)
 
         # Listen for the preference value being changed.
         components = self.preference_path.split(".")

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -24,19 +24,20 @@ from apptools.preferences.api import Preferences
 from apptools.preferences.api import bind_preference
 from apptools.preferences.api import set_default_preferences
 from traits.api import Bool, HasTraits, Int, Float, Str
+from traits.observation.api import match
 
 
 # This module's package.
 PKG = "apptools.preferences.tests"
 
 
-def listener(obj, trait_name, old, new):
+def listener(event):
     """ A useful trait change handler for testing! """
 
-    listener.obj = obj
-    listener.trait_name = trait_name
-    listener.old = old
-    listener.new = new
+    listener.obj = event.object
+    listener.trait_name = event.name
+    listener.old = event.old
+    listener.new = event.new
 
 
 class PreferenceBindingTestCase(unittest.TestCase):
@@ -77,7 +78,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
             visible = Bool
 
         acme_ui = AcmeUI()
-        acme_ui.on_trait_change(listener)
+        acme_ui.observe(listener, match(lambda n, t: True))
 
         # Make some bindings.
         bind_preference(acme_ui, "bgcolor", "acme.ui.bgcolor")
@@ -228,7 +229,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
             visible = Bool
 
         acme_ui = AcmeUI()
-        acme_ui.on_trait_change(listener)
+        acme_ui.observe(listener, match(lambda n, t: True))
 
         # Create an empty preferences node and use that in some of the
         # bindings!
@@ -267,7 +268,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
                 self.ratio = 3.0
 
         acme_ui = AcmeUI()
-        acme_ui.on_trait_change(listener)
+        acme_ui.observe(listener, match(lambda n, t: True))
 
         # Make some bindings.
         bind_preference(acme_ui, "bgcolor", "acme.ui.bgcolor")
@@ -304,7 +305,7 @@ class PreferenceBindingTestCase(unittest.TestCase):
             color = Str
 
         acme_ui = AcmeUI()
-        acme_ui.on_trait_change(listener)
+        acme_ui.observe(listener, match(lambda n, t: True))
 
         # Make some bindings.
         bind_preference(acme_ui, "color", "acme.ui.bgcolor")

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -27,22 +27,23 @@ from traits.api import (
     Any, Bool, HasTraits, Int, Float, List, Str,
     push_exception_handler, pop_exception_handler,
 )
+from traits.observation.api import match
 
 
-def width_listener(obj, trait_name, old, new):
+def width_listener(event):
 
-    width_listener.obj = obj
-    width_listener.trait_name = trait_name
-    width_listener.old = old
-    width_listener.new = new
+    width_listener.obj = event.object
+    width_listener.trait_name = event.name
+    width_listener.old = event.old
+    width_listener.new = event.new
 
 
-def bgcolor_listener(obj, trait_name, old, new):
+def bgcolor_listener(event):
 
-    bgcolor_listener.obj = obj
-    bgcolor_listener.trait_name = trait_name
-    bgcolor_listener.old = old
-    bgcolor_listener.new = new
+    bgcolor_listener.obj = event.object
+    bgcolor_listener.trait_name = event.name
+    bgcolor_listener.old = event.old
+    bgcolor_listener.new = event.new
 
 
 # This module's package.
@@ -105,7 +106,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names = List(Str)
 
         helper = AcmeUIPreferencesHelper()
-        helper.on_trait_change(bgcolor_listener)
+        helper.observe(bgcolor_listener, match(lambda n, t: True))
 
         # Make sure the helper was initialized properly.
         self.assertEqual("blue", helper.bgcolor)
@@ -157,7 +158,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             names = List(Str)
 
         helper = AcmeUIPreferencesHelper(preferences_path="acme.ui")
-        helper.on_trait_change(bgcolor_listener)
+        helper.observe(bgcolor_listener, match(lambda n, t: True))
 
         # Make sure the helper was initialized properly.
         self.assertEqual("blue", helper.bgcolor)
@@ -344,7 +345,7 @@ class PreferencesHelperTestCase(unittest.TestCase):
             background_color = Str
 
         w = Widget()
-        w.on_trait_change(bgcolor_listener)
+        w.observe(bgcolor_listener, match(lambda n, t: True))
 
         p = self.preferences
         p.load(self.example)
@@ -480,8 +481,8 @@ class PreferencesHelperTestCase(unittest.TestCase):
         helper = AcmeUIPreferencesHelper()
 
         # We only listen to some of the traits so the testing is easier.
-        helper.on_trait_change(width_listener, ["width"])
-        helper.on_trait_change(bgcolor_listener, ["bgcolor"])
+        helper.observe(width_listener, ["width"])
+        helper.observe(bgcolor_listener, ["bgcolor"])
 
         # Create a new preference node.
         p1 = Preferences()

--- a/apptools/preferences/ui/widget_editor.py
+++ b/apptools/preferences/ui/widget_editor.py
@@ -41,7 +41,7 @@ class _WidgetEditor(Editor):
         self.control = page.create_control(parent)
 
         # Listen for the page being changed.
-        self.object.observe(self._on_page_changed, "selected_page")
+        self.object.observe(self._handle_change_to_selected_page, "selected_page")
 
     def dispose(self):
         """ Dispose of the editor. """
@@ -58,7 +58,7 @@ class _WidgetEditor(Editor):
     # Private interface.
     ###########################################################################
 
-    def _on_page_changed(self, event):
+    def _handle_change_to_selected_page(self, event):
         """ Dynamic trait change handler. """
 
         if event.old is not None:

--- a/apptools/preferences/ui/widget_editor.py
+++ b/apptools/preferences/ui/widget_editor.py
@@ -11,7 +11,7 @@
 
 
 # Enthought library imports.
-from traits.api import Any
+from traits.api import Any, observe
 from traitsui.api import EditorFactory
 from traitsui.toolkit import toolkit_object
 Editor = toolkit_object('editor:Editor')
@@ -40,9 +40,6 @@ class _WidgetEditor(Editor):
         # Create the editor's control.
         self.control = page.create_control(parent)
 
-        # Listen for the page being changed.
-        self.object.observe(self._handle_change_to_selected_page, "selected_page")
-
     def dispose(self):
         """ Dispose of the editor. """
 
@@ -58,6 +55,7 @@ class _WidgetEditor(Editor):
     # Private interface.
     ###########################################################################
 
+    @observe("object:selected_page")
     def _handle_change_to_selected_page(self, event):
         """ Dynamic trait change handler. """
 

--- a/apptools/preferences/ui/widget_editor.py
+++ b/apptools/preferences/ui/widget_editor.py
@@ -41,7 +41,7 @@ class _WidgetEditor(Editor):
         self.control = page.create_control(parent)
 
         # Listen for the page being changed.
-        self.object.on_trait_change(self._on_page_changed, "selected_page")
+        self.object.observe(self._on_page_changed, "selected_page")
 
     def dispose(self):
         """ Dispose of the editor. """
@@ -58,14 +58,14 @@ class _WidgetEditor(Editor):
     # Private interface.
     ###########################################################################
 
-    def _on_page_changed(self, obj, trait_name, old, new):
+    def _on_page_changed(self, event):
         """ Dynamic trait change handler. """
 
-        if old is not None:
-            old.destroy_control()
+        if event.old is not None:
+            event.old.destroy_control()
 
-        if new is not None:
-            self.control = new.create_control(self.parent)
+        if event.new is not None:
+            self.control = event.new.create_control(self.parent)
 
 
 class WidgetEditor(EditorFactory):

--- a/apptools/scripting/recorder_with_ui.py
+++ b/apptools/scripting/recorder_with_ui.py
@@ -11,7 +11,7 @@
 A Recorder subclass that presents a simple user interface.
 """
 
-from traits.api import Code, Button, Int, on_trait_change, Any
+from traits.api import Code, Button, Int, observe, Any
 from traitsui.api import View, Item, Group, HGroup, CodeEditor, spring, Handler
 
 from .recorder import Recorder
@@ -88,8 +88,8 @@ class RecorderWithUI(Recorder):
     ######################################################################
     # Non-public interface.
     ######################################################################
-    @on_trait_change("lines[]")
-    def _update_code(self):
+    @observe("lines.items")
+    def _update_code(self, event):
         self.code = self.get_code()
         self.current_line = len(self.lines) + 1
 

--- a/docs/releases/upcoming/285.feature.rst
+++ b/docs/releases/upcoming/285.feature.rst
@@ -1,0 +1,1 @@
+start replacing on_trait_change with observe (#285)


### PR DESCRIPTION
**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)


This PR replaces _almost_ all uses of `on_trait_change` with observe.

All that remains is `apptools.selection.selection_service.py` and `apptools.scripting.recorder.py` (also an undo example but that is deprecated here anyway).  These are a bit trickier and can be addressed separately