### PR TITLE
Replace use of envisage "contributes_to" decorator in docs

### DIFF
--- a/docs/source/preferences/PreferencesInEnvisage.rst
+++ b/docs/source/preferences/PreferencesInEnvisage.rst
@@ -38,11 +38,16 @@ loaded into the default scope when the application is started.
 
 e.g. To contribute a preference file for my plugin I might use::
 
+  from envisage.ids import PREFERENCES
+  ...
+
+
   class MyPlugin(Plugin):
       ...
+      
+      contributed_preferences = List(contributes_to=PREFERENCES)
 
-      @contributes_to('envisage.preferences')
-      def get_preferences(self, application):
+      def _contributed_preferences_default(self):
           return ['pkgfile://mypackage:preferences.ini']
 
 ..


### PR DESCRIPTION
This PR removes the use of envisage `@contributes_to` decorator in favor of a trait `List` with metadata `contributes_to` instead. This is being done because the next release of envisage removes the decorator entirely. Ref https://github.com/enthought/envisage/pull/402