### PR TITLE
Port CI to gh-actions

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -1,7 +1,3 @@
-# This workflow targets stable released dependencies from EDM.
-# Note that some packages may not actually be installed from EDM but from
-# PyPI, see etstool.py implementations.
-
 name: Test with EDM using ETS packages from source
 
 on:
@@ -14,7 +10,7 @@ env:
 
 jobs:
 
-  # Test against EDM packages on Windows and OSX
+  # Test against EDM packages
   test-with-edm:
     strategy:
       matrix:

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -1,0 +1,47 @@
+# This workflow targets stable released dependencies from EDM.
+# Note that some packages may not actually be installed from EDM but from
+# PyPI, see etstool.py implementations.
+
+name: Test with EDM using ETS packages from source
+
+on:
+  schedule:
+    - cron:  '0 0 * * 5'
+
+
+env:
+  INSTALL_EDM_VERSION: 3.2.3
+
+jobs:
+
+  # Test against EDM packages on Windows and OSX
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      # Set root directory, mainly for Windows, so that the EDM Python
+      # environment lives in the same drive as the cloned source. Otherwise
+      # 'pip install' raises an error while trying to compute
+      # relative path between the site-packages and the source directory.
+      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python etstool.py install --source
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: edm run -- python etstool.py test

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -1,0 +1,47 @@
+# This workflow targets stable released dependencies from EDM.
+# Note that some packages may not actually be installed from EDM but from
+# PyPI, see etstool.py implementations.
+
+name: Test with EDM
+
+on: pull_request
+
+env:
+  INSTALL_EDM_VERSION: 3.2.3
+
+jobs:
+
+  # Test against EDM packages on Windows and OSX
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      # Set root directory, mainly for Windows, so that the EDM Python
+      # environment lives in the same drive as the cloned source. Otherwise
+      # 'pip install' raises an error while trying to compute
+      # relative path between the site-packages and the source directory.
+      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python etstool.py install
+      - name: Flake8
+        run: edm run -- python etstool.py flake8
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: edm run -- python etstool.py test

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
 
-  # Test against EDM packages on Windows and OSX
+  # Test against EDM packages
   test-with-edm:
     strategy:
       matrix:


### PR DESCRIPTION
Part of #287 (which can be closed when we drop travis and appveyor)
This PR adds two _nearly_ identical work flows.  One of which will run the test suite and flake8 on every PR using packages from edm, the other which will run the test suite as a cron job using ets packages from source. 

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
