### PR TITLE
Replace Property depends_on with observe

### DIFF
--- a/apptools/logger/plugin/view/logger_view.py
+++ b/apptools/logger/plugin/view/logger_view.py
@@ -95,10 +95,10 @@ class LoggerView(TraitsUIView):
     service = Instance(LoggerService)
 
     log_records = List(Instance(logging.LogRecord))
-    formatted_records = Property(Str, depends_on="log_records")
+    formatted_records = Property(Str, observe="log_records")
 
     activated = Instance(logging.LogRecord)
-    activated_text = Property(Str, depends_on="activated")
+    activated_text = Property(Str, observe="activated")
     reset_button = Button("Reset Logs")
     show_button = Button("Complete Text Log")
     copy_button = Button("Copy Log to Clipboard")

--- a/apptools/naming/tests/test_object_serializer.py
+++ b/apptools/naming/tests/test_object_serializer.py
@@ -22,7 +22,7 @@ class FooWithTraits(HasTraits):
 
     full_name = Str()
 
-    last_name = Property(depends_on="full_name")
+    last_name = Property(observe="full_name")
 
     event = Event()
 

--- a/setup.py
+++ b/setup.py
@@ -304,6 +304,7 @@ if __name__ == "__main__":
         },
         install_requires=[
             'configobj',
+            'traits>=6.2.0',
             'traitsui',
         ],
         extras_require={


### PR DESCRIPTION
Note these changes now make `apptools` require traits >= 6.2.  ~I checked to specify this requirement, but it appears as though traits isn't even explicitly listed as a requirement, but rather is implicitly required through `traitsui` (which now explicitly requires traits >= 6.2).~ EDIT: I've added `traits>=6.2.0` as an explicit required dependency on this PR.

https://github.com/enthought/apptools/blob/96c3af4213f0d3ab2c831f4e2949a5170d6ff96c/setup.py#L305-L308

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
