### PR TITLE
Add news fragment for PR 289

### DIFF
--- a/docs/releases/upcoming/289.feature.rst
+++ b/docs/releases/upcoming/289.feature.rst
@@ -1,0 +1,1 @@
+Replace Property depends_on with observe (#289)


### PR DESCRIPTION
Adds a news fragment for #289 as it was merged without one.  I labelled it as "feature", but we should probably add a maintenance option?  We have a "maintenance" section in other ets project changelogs.
**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
This PR is not news-worthy
