### PR TITLE
Setup slack notification for cron job

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -42,3 +42,31 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: edm run -- python etstool.py test
+
+  notify-on-failure:
+    needs: test-with-edm
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test-with-edm
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}


### PR DESCRIPTION
This PR sets up slack notification for the cron job. I manually triggered the cron job on this branch to ensure that the slack notification actually worked as expected. Ref https://github.com/enthought/apptools/actions/runs/1027301837

One more step towards https://github.com/enthought/ets/issues/65.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
