### PR TITLE
Add an RtD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -308,6 +308,7 @@ if __name__ == "__main__":
             'traitsui',
         ],
         extras_require={
+            "docs": ["enthought-sphinx-theme", "sphinx"],
             "test": [
                 "importlib-resources>=1.1.0; python_version<'3.9'",
             ],


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. These changes are based on enthought/traits#1478. This is one more step towards enthought/ets#69.

This PR also add a `docs` `extras_require` when installing traitsui to make it easy to build the sphinx docs.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
