### PR TITLE
Remove unnecessary if/elif/else code branch

### DIFF
--- a/apptools/preferences/preference_binding.py
+++ b/apptools/preferences/preference_binding.py
@@ -101,10 +101,6 @@ class PreferenceBinding(HasTraits):
         if type(handler) is Str:
             pass
 
-        # If the trait type is 'Str' then we convert the raw value.
-        elif type(handler) is Str:
-            value = str(value)
-
         # Otherwise, we eval it!
         else:
             try:


### PR DESCRIPTION
This PR removes an unnecessary if/elif/else code branch that became redundant when we removed the use of six and Unicode trait type from the codebase

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~
