### PR TITLE
Add workflow that tests against pip packages for various Python versions

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Notify Slack channel on failure
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          channel_id: ${{ secrets.ETS_SLACK_CHANNEL_ID }}
           status: FAILED
           color: danger
         env:

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip
         python -m pip install .[h5,preferences]
     - name: Run tests
       run: |

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout apptools source
+    - name: Get apptools source
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -1,0 +1,29 @@
+name: Test with pip
+
+on:
+- pull_request
+- workflow_dispatch
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.6', '3.8', '3.10']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout apptools source
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+    - name: Install dependencies and local packages
+      run: |
+        python -m pip install --upgrade pip wheel
+        python -m pip install .[h5,preferences]
+    - name: Run tests
+      run: |
+        mkdir testdir
+        cd testdir
+        python -m unittest discover -v apptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
This PR adds a simple GitHub actions workflow, triggered on pull request (and optionally also manually) that runs the test suite on Python 3.6, 3.8 and 3.10 in a standard Python environment (rather than an EDM environment). The goal is to catch issues like #303 earlier.

---

EDIT: PR updated to also include a `pyproject.toml` file.