### PR TITLE
Bump version for 5.2.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 5
 MINOR = 2
 MICRO = 0
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR bumps the version for the 5.2 release.

Note: I'm making a PR to get feedback from the CI (and possibly also from humans). The PR will not be merged. The commit d10438013898042e9178bf4612ae42f24e18d028 will be tagged as 5.2.0 once CI completes.