### PR TITLE
Avoid build isolation when installing source dependencies

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -204,8 +204,20 @@ def install(edm, runtime, environment, source):
         source_pkgs = [
             github_url_fmt.format(pkg) for pkg in source_dependencies
         ]
+
+        # Install build prerequisites from EDM (needed because we're avoiding
+        # build isolation below).
+        commands = ["{edm} install -y -e {environment} setuptools wheel"]
+        execute(commands, parameters)
+
+        # --no-build-isolation is necessary to temporarily work around
+        # an incompatibility between setuptools >= 65.2.0 and the EDM runtimes.
+        # See enthought/traits#1721.
         commands = [
-            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
+            (
+                "python -m pip install --no-build-isolation "
+                "{pkg} --no-deps"
+            ).format(pkg=pkg)
             for pkg in source_pkgs
         ]
         commands = [


### PR DESCRIPTION
Currently building Traits from source fails thanks to an incompatibility between recent setuptools and EDM runtimes. This PR adds the --no-build-isolation flag so that the build uses the version of setuptools already in the EDM environment rather than the latest version from PyPI.

xref: enthought/traits#1721