### PR TITLE
FIX: add encoding as an attribute for LogFileHandler initialization

### DIFF
--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -29,7 +29,13 @@ class LogFileHandler(RotatingFileHandler):
     """The default log file handler."""
 
     def __init__(
-        self, path, maxBytes=1000000, backupCount=3, level=None, formatter=None, encoding=None
+        self,
+        path,
+        maxBytes=1000000,
+        backupCount=3,
+        level=None,
+        formatter=None,
+        encoding=None,
     ):
         RotatingFileHandler.__init__(
             self, path, maxBytes=maxBytes, backupCount=3, encoding=encoding

--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -31,14 +31,22 @@ class LogFileHandler(RotatingFileHandler):
     def __init__(
         self,
         path,
+        mode="a",
         maxBytes=1000000,
         backupCount=3,
         level=None,
         formatter=None,
         encoding=None,
+        delay=False,
     ):
         RotatingFileHandler.__init__(
-            self, path, maxBytes=maxBytes, backupCount=3, encoding=encoding
+            self,
+            path=path,
+            mode=mode,
+            maxBytes=maxBytes,
+            backupCount=backupCount,
+            encoding=encoding,
+            delay=delay,
         )
 
         if level is None:

--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -41,7 +41,7 @@ class LogFileHandler(RotatingFileHandler):
     ):
         RotatingFileHandler.__init__(
             self,
-            path=path,
+            filename=path,
             mode=mode,
             maxBytes=maxBytes,
             backupCount=backupCount,

--- a/apptools/logger/logger.py
+++ b/apptools/logger/logger.py
@@ -29,10 +29,10 @@ class LogFileHandler(RotatingFileHandler):
     """The default log file handler."""
 
     def __init__(
-        self, path, maxBytes=1000000, backupCount=3, level=None, formatter=None
+        self, path, maxBytes=1000000, backupCount=3, level=None, formatter=None, encoding=None
     ):
         RotatingFileHandler.__init__(
-            self, path, maxBytes=maxBytes, backupCount=3
+            self, path, maxBytes=maxBytes, backupCount=3, encoding=encoding
         )
 
         if level is None:


### PR DESCRIPTION
Fix for #323 

Simply adds `encoding` as attribute for `LogFileHandler`.