### PR TITLE
Fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  INSTALL_EDM_VERSION: 3.3.1
+  INSTALL_EDM_VERSION: 3.5.0
 
 jobs:
 
@@ -36,7 +36,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -41,12 +41,8 @@ jobs:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment
         run: python etstool.py install --runtime=${{ matrix.runtime }} --source
-      - name: Run tests under xvfb
-        run: xvfb-run -a python etstool.py test --runtime=${{ matrix.runtime }}
-        if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
         run: python etstool.py test --runtime=${{ matrix.runtime }}
-        if: '!startsWith(matrix.os, ''ubuntu'')'
 
   notify-on-failure:
     needs: test-with-edm

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -46,7 +46,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
         run: python etstool.py test --runtime=${{ matrix.runtime }}
-        if: '!startsWith(matrix.os, ''ubuntu''')'
+        if: '!startsWith(matrix.os, ''ubuntu'')'
 
   notify-on-failure:
     needs: test-with-edm

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -41,10 +41,12 @@ jobs:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment
         run: python etstool.py install --runtime=${{ matrix.runtime }} --source
+      - name: Run tests under xvfb
+        run: xvfb-run -a python etstool.py test --runtime=${{ matrix.runtime }}
+        if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: python etstool.py test --runtime=${{ matrix.runtime }}
+        run: python etstool.py test --runtime=${{ matrix.runtime }}
+        if: '!startsWith(matrix.os, ''ubuntu''')'
 
   notify-on-failure:
     needs: test-with-edm

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -18,7 +18,6 @@ jobs:
         python-version: '3.10'
     - name: Install Python packages needed for build and upload
       run: |
-        python -m pip install --upgrade pip
         python -m pip install build twine
     - name: Build sdist and wheel
       run: |

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: [pull_request, workflow_dispatch]
 
 env:
-  INSTALL_EDM_VERSION: 3.3.1
+  INSTALL_EDM_VERSION: 3.5.0
 
 jobs:
 
@@ -36,7 +36,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -49,4 +49,4 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
         run: python etstool.py test --runtime=${{ matrix.runtime }}
-        if: '!startsWith(matrix.os, ''ubuntu''')'
+        if: '!startsWith(matrix.os, ''ubuntu'')'

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Run style checks (only on Linux)
         run: python etstool.py flake8 --runtime=${{ matrix.runtime }}
         if: startsWith(matrix.os, 'ubuntu')
+      - name: Run tests under xvfb
+        run: xvfb-run -a python etstool.py test --runtime=${{ matrix.runtime }}
+        if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: python etstool.py test --runtime=${{ matrix.runtime }}
+        run: python etstool.py test --runtime=${{ matrix.runtime }}
+        if: '!startsWith(matrix.os, ''ubuntu''')'

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -44,9 +44,5 @@ jobs:
       - name: Run style checks (only on Linux)
         run: python etstool.py flake8 --runtime=${{ matrix.runtime }}
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Run tests under xvfb
-        run: xvfb-run -a python etstool.py test --runtime=${{ matrix.runtime }}
-        if: startsWith(matrix.os, 'ubuntu')
       - name: Run tests
         run: python etstool.py test --runtime=${{ matrix.runtime }}
-        if: '!startsWith(matrix.os, ''ubuntu'')'

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.8', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -22,7 +22,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install --upgrade pip
         python -m pip install .[h5,preferences]
     - name: Run tests
       run: |

--- a/etstool.py
+++ b/etstool.py
@@ -303,7 +303,9 @@ def flake8(edm, runtime, environment):
         "integrationtests",
     ]
     commands = [
-        "{edm} run -e {environment} -- python -m flake8 " + " ".join(targets)
+        "{edm} run -e {environment} -- python -m flake8 "
+        + "--copyright-end-year 2022 "
+        + " ".join(targets)
     ]
     execute(commands, parameters)
 


### PR DESCRIPTION
This PR brings our continuous integration workflows back to working state

- Don't try to run non-EDM-based tests on Python 3.6
- Remove uses of GabrielBB/xvfb-action (we don't actually need a virtual framebuffer at all)
- Temporarily pin the copyright end year; we'll fix the copyright headers in a followup PR
- Update EDM and setup-edm-action versions
- Other minor cleanups - e.g., don't update `pip` unnecessarily (the setup-python action already does this for us)

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
