### PR TITLE
Drop Python 3.6 from source builds

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        runtime: ['3.6', '3.8']
+        runtime: ['3.8']
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Upstream packages have dropped, or are in the process of dropping, support for Python 3.6. So for our `ets-from-source` workflow, we should also drop the Python 3.6 support. (We'll also want to do this eventually in the main workflow.)

This incidentally fixes an issue where for the 3.6 workflow we were pulling in an ancient version of `setuptools` from EDM, while some of the apptools dependencies needed a newer version of `setuptools`. We _could_ adapt `etstool.py` to support that case by installing `setuptools` from PyPI instead of from EDM, but given that Python 3.6 is going away, it doesn't really seem worth the effort at this point.

No changelog entry because this change isn't interesting for end users.

May close #329
