### PR TITLE
Don't run macOS tests with EDM-based workflows

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -15,7 +15,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         runtime: ['3.8']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -15,7 +15,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest']
         runtime: ['3.6', '3.8']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR removes macOS tests for the EDM-based workflows: the EDM builds of NumPy use the AVX2 instruction set, and as 
a result are incompatible with the GitHub Actions runners on macOS.