### PR TITLE
Remove uses of numpy.alltrue

### DIFF
--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -172,7 +172,7 @@ class TestDictPickler(unittest.TestCase):
             base64.decodebytes(data[num_attr]["data"])
         )
         num = pickle.loads(junk)
-        self.assertEqual(numpy.alltrue(numpy.ravel(num == obj.numeric)), 1)
+        self.assertEqual(numpy.all(numpy.ravel(num == obj.numeric)), 1)
 
         self.assertIn(data["ref"]["type"], ["reference", "numeric"])
         if data["ref"]["type"] == "numeric":
@@ -218,7 +218,7 @@ class TestDictPickler(unittest.TestCase):
         self.assertEqual(dct["ref"].__metadata__["type"], "instance")
 
         num = state.numeric
-        self.assertEqual(numpy.alltrue(numpy.ravel(num == obj.numeric)), 1)
+        self.assertEqual(numpy.all(numpy.ravel(num == obj.numeric)), 1)
         self.assertEqual(id(state.ref), id(num))
 
         if TVTK_AVAILABLE:

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -172,7 +172,7 @@ class TestDictPickler(unittest.TestCase):
             base64.decodebytes(data[num_attr]["data"])
         )
         num = pickle.loads(junk)
-        numpy.testing.assert_array_equal(num, obj.numeric, strict=True)
+        numpy.testing.assert_array_equal(num, obj.numeric)
 
         self.assertIn(data["ref"]["type"], ["reference", "numeric"])
         if data["ref"]["type"] == "numeric":
@@ -218,7 +218,7 @@ class TestDictPickler(unittest.TestCase):
         self.assertEqual(dct["ref"].__metadata__["type"], "instance")
 
         num = state.numeric
-        numpy.testing.assert_array_equal(num, obj.numeric, strict=True)
+        numpy.testing.assert_array_equal(num, obj.numeric)
         self.assertEqual(id(state.ref), id(num))
 
         if TVTK_AVAILABLE:

--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -172,7 +172,7 @@ class TestDictPickler(unittest.TestCase):
             base64.decodebytes(data[num_attr]["data"])
         )
         num = pickle.loads(junk)
-        self.assertEqual(numpy.all(numpy.ravel(num == obj.numeric)), 1)
+        numpy.testing.assert_array_equal(num, obj.numeric, strict=True)
 
         self.assertIn(data["ref"]["type"], ["reference", "numeric"])
         if data["ref"]["type"] == "numeric":
@@ -218,7 +218,7 @@ class TestDictPickler(unittest.TestCase):
         self.assertEqual(dct["ref"].__metadata__["type"], "instance")
 
         num = state.numeric
-        self.assertEqual(numpy.all(numpy.ravel(num == obj.numeric)), 1)
+        numpy.testing.assert_array_equal(num, obj.numeric, strict=True)
         self.assertEqual(id(state.ref), id(num))
 
         if TVTK_AVAILABLE:

--- a/docs/releases/upcoming/341.bugfix.rst
+++ b/docs/releases/upcoming/341.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced uses of ``numpy.alltrue``, for compatibility with NumPy 2.0.


### PR DESCRIPTION
This PR removes uses of `numpy.alltrue`, which no longer exists in NumPy 2.0.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
