### PR TITLE
Avoid writing to preferences on helper creation

### DIFF
--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -100,7 +100,7 @@ class PreferencesHelper(HasTraits):
         # the trait is not a preference trait and we do nothing.
 
     @observe("preferences", post_init=True)
-    def _preferences_changed(self, event):
+    def _update_preferences_listeners(self, event):
         """Update listeners when the preferences object changes."""
 
         old, new = event.old, event.new

--- a/apptools/preferences/preferences_helper.py
+++ b/apptools/preferences/preferences_helper.py
@@ -15,7 +15,7 @@ from ast import literal_eval
 import logging
 
 # Enthought library imports.
-from traits.api import HasTraits, Instance, Str
+from traits.api import HasTraits, Instance, Str, observe
 
 # Local imports.
 from .i_preferences import IPreferences
@@ -99,8 +99,11 @@ class PreferencesHelper(HasTraits):
         # If the change refers to a trait defined on this class, then
         # the trait is not a preference trait and we do nothing.
 
-    def _preferences_changed(self, old, new):
-        """ Static trait change handler. """
+    @observe("preferences", post_init=True)
+    def _preferences_changed(self, event):
+        """Update listeners when the preferences object changes."""
+
+        old, new = event.old, event.new
 
         # Stop listening to the old preferences node.
         if old is not None:

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -602,3 +602,26 @@ class PreferencesHelperTestCase(unittest.TestCase):
         # attempt to create instance from invalid value
         with self.assertRaises(TraitError):
             AcmeUIPreferencesHelper(preferences_path="acme.ui")
+
+    def test_preferences_not_written_on_helper_creation(self):
+
+        class AppPreferencesHelper(PreferencesHelper):
+            #: The node that contains the preferences.
+            preferences_path = "app"
+
+            #: The user's favourite colour
+            color = Str()
+
+        default_preferences = Preferences(name="default")
+        default_preferences.set("app.color", "red")
+
+        application_preferences = Preferences(name="application")
+        preferences = ScopedPreferences(
+            scopes=[application_preferences, default_preferences]
+        )
+        self.assertIsNone(application_preferences.get("app.color"))
+
+        # Then creation of the helper should not cause the application
+        # preferences to change.
+        AppPreferencesHelper(preferences=preferences)
+        self.assertIsNone(application_preferences.get("app.color"))

--- a/docs/releases/upcoming/343.bugfix.rst
+++ b/docs/releases/upcoming/343.bugfix.rst
@@ -1,0 +1,1 @@
+Don't write to preferences on ``PreferencesHelper`` creation. (#343)


### PR DESCRIPTION
This PR fixes the `PreferencesHelper` to avoid writing to the preferences the first time a helper is created for a given `Preferences` object.

The issue was that on creation, `PreferencesHelper._initialize` was being called twice: once with `notify=False` and again with `notify=True`, as a result of the listener to the `preferences` trait. This PR avoids the second call by making that listener only run post creation (using `post_init=True`).

Closes #342
Closes #74

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
