### PR TITLE
Make TraitsUI, Pyface and configobj optional dependencies

### DIFF
--- a/.github/workflows/test-minimal-dependencies.yml
+++ b/.github/workflows/test-minimal-dependencies.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-minimal-dependencies.yml
+++ b/.github/workflows/test-minimal-dependencies.yml
@@ -1,4 +1,4 @@
-name: Test with pip
+name: Test with minimal dependencies
 
 on:
 - pull_request
@@ -20,14 +20,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies and local packages (not macOS)
-      run: python -m pip install .[gui,h5,preferences]
-      if: matrix.os != 'macos-latest'
-    - name: Install dependencies and local packages (macOS)
-      run: python -m pip install .[gui,preferences]
-      # PyTables currently won't build on Apple Silicon, so exclude the h5 deps
-      # xref: enthought/apptools/issues/344
-      if: matrix.os == 'macos-latest'
+    - name: Install local package
+      run: python -m pip install .
     - name: Run tests
       run: |
         mkdir testdir

--- a/.github/workflows/test-minimal-dependencies.yml
+++ b/.github/workflows/test-minimal-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install local package
-      run: python -m pip install .
+      run: python -m pip install ".[test]"
     - name: Run tests
       run: |
         mkdir testdir

--- a/apptools/_testing/optional_dependencies.py
+++ b/apptools/_testing/optional_dependencies.py
@@ -45,3 +45,12 @@ requires_pandas = unittest.skipIf(pandas is None, "Pandas not available")
 
 tables = optional_import("tables")
 requires_tables = unittest.skipIf(tables is None, "PyTables not available")
+
+configobj = optional_import("configobj")
+requires_configobj = unittest.skipIf(configobj is None, "configobj not available")
+
+pyface = optional_import("pyface")
+requires_pyface = unittest.skipIf(pyface is None, "Pyface not available")
+
+traitsui = optional_import("traitsui")
+requires_traitsui = unittest.skipIf(traitsui is None, "TraitsUI not available")

--- a/apptools/_testing/optional_dependencies.py
+++ b/apptools/_testing/optional_dependencies.py
@@ -47,7 +47,9 @@ tables = optional_import("tables")
 requires_tables = unittest.skipIf(tables is None, "PyTables not available")
 
 configobj = optional_import("configobj")
-requires_configobj = unittest.skipIf(configobj is None, "configobj not available")
+requires_configobj = unittest.skipIf(
+    configobj is None, "configobj not available"
+)
 
 pyface = optional_import("pyface")
 requires_pyface = unittest.skipIf(pyface is None, "Pyface not available")

--- a/apptools/logger/plugin/tests/test_logger_service.py
+++ b/apptools/logger/plugin/tests/test_logger_service.py
@@ -11,9 +11,13 @@ from email.mime.multipart import MIMEMultipart
 import unittest
 from unittest import mock
 
-from apptools.logger.plugin.logger_service import LoggerService
+from apptools._testing.optional_dependencies import pyface, requires_pyface
+
+if pyface is not None:
+    from apptools.logger.plugin.logger_service import LoggerService
 
 
+@requires_pyface
 class LoggerServiceTestCase(unittest.TestCase):
     def test_create_email_message(self):
         logger_service = LoggerService()

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -26,6 +26,8 @@ except ImportError:
 from apptools.preferences.api import Preferences
 from apptools.preferences.api import bind_preference
 from apptools.preferences.api import set_default_preferences
+from apptools._testing.optional_dependencies import configobj, requires_configobj
+
 from traits.api import Bool, HasTraits, Int, Float, Str, TraitError
 from traits.observation.api import match
 
@@ -43,6 +45,7 @@ def listener(event):
     listener.new = event.new
 
 
+@requires_configobj
 class PreferenceBindingTestCase(unittest.TestCase):
     """ Tests for preference bindings. """
 

--- a/apptools/preferences/tests/test_preference_binding.py
+++ b/apptools/preferences/tests/test_preference_binding.py
@@ -26,7 +26,7 @@ except ImportError:
 from apptools.preferences.api import Preferences
 from apptools.preferences.api import bind_preference
 from apptools.preferences.api import set_default_preferences
-from apptools._testing.optional_dependencies import configobj, requires_configobj
+from apptools._testing.optional_dependencies import requires_configobj
 
 from traits.api import Bool, HasTraits, Int, Float, Str, TraitError
 from traits.observation.api import match

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -23,6 +23,7 @@ except ImportError:
     from importlib_resources import files
 
 # Enthought library imports.
+from apptools._testing.optional_dependencies import configobj, requires_configobj
 from apptools.preferences.api import Preferences
 
 
@@ -30,6 +31,7 @@ from apptools.preferences.api import Preferences
 PKG = "apptools.preferences.tests"
 
 
+@requires_configobj
 class PreferencesTestCase(unittest.TestCase):
     """ Tests for preferences nodes. """
 

--- a/apptools/preferences/tests/test_preferences.py
+++ b/apptools/preferences/tests/test_preferences.py
@@ -23,7 +23,7 @@ except ImportError:
     from importlib_resources import files
 
 # Enthought library imports.
-from apptools._testing.optional_dependencies import configobj, requires_configobj
+from apptools._testing.optional_dependencies import requires_configobj
 from apptools.preferences.api import Preferences
 
 

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -26,7 +26,7 @@ except ImportError:
 from apptools.preferences.api import Preferences, PreferencesHelper
 from apptools.preferences.api import ScopedPreferences
 from apptools.preferences.api import set_default_preferences
-from apptools._testing.optional_dependencies import configobj, requires_configobj
+from apptools._testing.optional_dependencies import requires_configobj
 
 from traits.api import (
     Any, Bool, HasTraits, Int, Float, List, Str, TraitError,

--- a/apptools/preferences/tests/test_preferences_helper.py
+++ b/apptools/preferences/tests/test_preferences_helper.py
@@ -26,6 +26,8 @@ except ImportError:
 from apptools.preferences.api import Preferences, PreferencesHelper
 from apptools.preferences.api import ScopedPreferences
 from apptools.preferences.api import set_default_preferences
+from apptools._testing.optional_dependencies import configobj, requires_configobj
+
 from traits.api import (
     Any, Bool, HasTraits, Int, Float, List, Str, TraitError,
     push_exception_handler, pop_exception_handler,
@@ -53,6 +55,7 @@ def bgcolor_listener(event):
 PKG = "apptools.preferences.tests"
 
 
+@requires_configobj
 class PreferencesHelperTestCase(unittest.TestCase):
     """ Tests for the preferences helper. """
 

--- a/apptools/preferences/ui/tests/test_preferences_page.py
+++ b/apptools/preferences/ui/tests/test_preferences_page.py
@@ -16,12 +16,16 @@ from traits.api import (
     pop_exception_handler,
     push_exception_handler,
 )
-from traitsui.api import Group, Item, View
 
 from apptools.preferences.api import Preferences
-from apptools.preferences.ui.api import PreferencesPage
+from apptools._testing.optional_dependencies import requires_traitsui, traitsui
+
+if traitsui is not None:
+    from traitsui.api import Group, Item, View
+    from apptools.preferences.ui.api import PreferencesPage
 
 
+@requires_traitsui
 class TestPreferencesPage(unittest.TestCase):
     """ Non-GUI Tests for PreferencesPage."""
 

--- a/docs/releases/upcoming/351.build.rst
+++ b/docs/releases/upcoming/351.build.rst
@@ -1,0 +1,3 @@
+TraitsUI, Pyface and configobj are now optional dependencies. TraitsUI
+and Pyface will be installed with ``pip install apptools[gui]``. configobj
+will be installed with ``pip install apptools[preferences]``. (#351)

--- a/setup.py
+++ b/setup.py
@@ -302,15 +302,15 @@ if __name__ == "__main__":
                 'preferences/tests/*.ini'
             ]
         },
-        install_requires=[
-            'configobj',
-            'traits>=6.2.0',
-            'traitsui',
-        ],
+        install_requires=['traits>=6.2.0'],
         extras_require={
             "docs": ["enthought-sphinx-theme", "sphinx"],
             "test": [
                 "importlib-resources>=1.1.0; python_version<'3.9'",
+            ],
+            "gui": [
+                "pyface",
+                "traitsui",
             ],
             "h5": [
                 # PyTables is currently incompatible with NumPy 2.0


### PR DESCRIPTION
Apptools contains several disparate packages with different needs. While it's somewhat reasonable to regard Traits as a core dependency, not all subpackages need a GUI, and only the preferences package makes use of configobj.

This PR:

* makes all three of TraitsUI, Pyface and configobj optional dependencies
* adds a "gui" entry for `extras_require` in `setup.py`
* adds a test workflow that runs the test suite with only the core dependencies (i.e., Traits), to make sure that other tests are skipped appropriately rather than failing

Closes #70 

Makes #86 obsolete.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
