### PR TITLE
Fix equality check in TVTK-related test

### DIFF
--- a/apptools/persistence/tests/test_state_pickler.py
+++ b/apptools/persistence/tests/test_state_pickler.py
@@ -251,7 +251,9 @@ class TestDictPickler(unittest.TestCase):
             ).__metadata__["id"]
 
         if TVTK_AVAILABLE:
-            self.assertEqual(state1._tvtk, state._tvtk)
+            # Some of the values are NumPy arrays, so use NumPy's
+            # assert_equal instead of the unittest assertEqual.
+            numpy.testing.assert_equal(state1._tvtk, state._tvtk)
 
         state1.tuple[-1].__metadata__["id"] = state.tuple[-1].__metadata__[
             "id"

--- a/docs/releases/upcoming/352.bugfix.rst
+++ b/docs/releases/upcoming/352.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a test that was broken in the presence of Mayavi / TVTK. (#352)


### PR DESCRIPTION
Closes #305.

Ideally we'd install Mayavi into the test environment in the test workflows, but I think that's too much of a maintenance risk. It would be even better to find a way to remove the TVTK-specific specializations altogether.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)
