### PR TITLE
Prepare for release of version 5.3.0 of apptools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,52 @@
 Apptools CHANGELOG
 ==================
 
+Version 5.3.0
+~~~~~~~~~~~~~
+
+Released: 2024-07-05
+
+This is a minor release, focusing primarily on bringing apptools up to date
+with respect to more recent versions of Python and 3rd party packages.
+Support for Python 3.7 has been dropped.
+
+Thanks to the following contributors:
+
+* Mark Dickinson
+* Stewart Ferguson
+* Frank Longford
+* Tony Ni
+* Sai Rahul Poruri
+
+Fixes
+-----
+* Drop support for Python 3.7. (#339)
+* Replaced uses of ``numpy.alltrue``, for compatibility with NumPy 2.0. (#341)
+* Don't write to preferences on ``PreferencesHelper`` creation. (#343)
+* Fix a test that was broken in the presence of Mayavi / TVTK. (#352)
+
+Documentation
+-------------
+* Moved Sphinx-generated man page to section 3. (#89)
+
+Build System
+------------
+* TraitsUI, Pyface and configobj are now optional dependencies. TraitsUI
+  and Pyface will be installed with ``pip install apptools[gui]``. configobj
+  will be installed with ``pip install apptools[preferences]``. (#351)
+
+
+Version 5.2.1
+~~~~~~~~~~~~~
+
+Released: 2023-06-23
+
+Fixes
+-----
+* Add missing attributes to ``LogFileHandler``, notably ``encoding``. (#324)
+* Fix StatePickler incompatibilities with Python >= 3.11. (#328)
+* Drop Python 3.6 support for source builds. (#330)
+
 Version 5.2.0
 ~~~~~~~~~~~~~
 

--- a/docs/releases/upcoming/328.bugfix.rst
+++ b/docs/releases/upcoming/328.bugfix.rst
@@ -1,1 +1,0 @@
-Fix StatePickler for Python 3.11. (#328)

--- a/docs/releases/upcoming/339.bugfix.rst
+++ b/docs/releases/upcoming/339.bugfix.rst
@@ -1,1 +1,0 @@
-Drop support for Python 3.7. (#339)

--- a/docs/releases/upcoming/341.bugfix.rst
+++ b/docs/releases/upcoming/341.bugfix.rst
@@ -1,1 +1,0 @@
-Replaced uses of ``numpy.alltrue``, for compatibility with NumPy 2.0.

--- a/docs/releases/upcoming/343.bugfix.rst
+++ b/docs/releases/upcoming/343.bugfix.rst
@@ -1,1 +1,0 @@
-Don't write to preferences on ``PreferencesHelper`` creation. (#343)

--- a/docs/releases/upcoming/351.build.rst
+++ b/docs/releases/upcoming/351.build.rst
@@ -1,3 +1,0 @@
-TraitsUI, Pyface and configobj are now optional dependencies. TraitsUI
-and Pyface will be installed with ``pip install apptools[gui]``. configobj
-will be installed with ``pip install apptools[preferences]``. (#351)

--- a/docs/releases/upcoming/352.bugfix.rst
+++ b/docs/releases/upcoming/352.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a test that was broken in the presence of Mayavi / TVTK. (#352)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 5
 MINOR = 3
 MICRO = 0
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR (against the `main` branch) bumps the version and updates the changelog in preparation for a 5.3.0 release of Apptools. The plan is to tag the merge commit from the eventual squash-merge of this PR.

@flongford Would you have bandwidth to review?