### PR TITLE
Drop a NumPy version pin that should no longer be necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,12 +313,17 @@ if __name__ == "__main__":
                 "traitsui",
             ],
             "h5": [
-                "numpy",
+                # For Python earlier than 3.10, the most recent version of
+                # PyTables is incompatible with NumPy 2.x.
+                # xref: https://github.com/enthought/apptools/issues/345
+                "numpy < 2.0; python_version<'3.10'",
+                "numpy; python_version>='3.10'",
                 "pandas",
                 "tables",
             ],
             "persistence": [
-                "numpy",
+                "numpy < 2.0; python_version<'3.10'",
+                "numpy; python_version>='3.10'",
             ],
             "preferences": [
                 "configobj",

--- a/setup.py
+++ b/setup.py
@@ -313,14 +313,12 @@ if __name__ == "__main__":
                 "traitsui",
             ],
             "h5": [
-                # PyTables is currently incompatible with NumPy 2.0
-                # xref: enthought/apptools#345
-                "numpy < 2.0",
+                "numpy",
                 "pandas",
                 "tables",
             ],
             "persistence": [
-                "numpy < 2.0",
+                "numpy",
             ],
             "preferences": [
                 "configobj",


### PR DESCRIPTION
This PR removes the `numpy < 2.0` dependency constraint, which should no longer be necessary.

Update: the pin is still needed for Python 3.9 and 3.8; it's been dropped for Python 3.10 and later.

Closes #345.