### PR TITLE
Update changelog and version number in preparation for 5.4.1 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,26 @@
 Apptools CHANGELOG
 ==================
 
+Version 5.3.1
+~~~~~~~~~~~~~
+
+Released: 2025-05-13
+
+This is a bugfix release that only affects packaging and build infrastructure.
+The core functionality is unchanged.
+
+Build
+-----
+* For Python >= 3.10, allow NumPy 2.x to be used. (#361)
+* Run HDF5-related tests on all platforms for Python >= 3.10. (#362)
+* Bump setup-edm-action from v3 to v4. (#359)
+* Remove the issue template. (#355)
+
+Documentation
+-------------
+* Copyrights have been updated for 2025. (#360)
+
+
 Version 5.3.0
 ~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 5
 MINOR = 4
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR updates the changelog and bumps the version number in preparation from the 5.4.1 release.

We're releasing from the main branch, since there are no feature-level changes since 5.4.0.