### PR TITLE
Be less strict about the copyright end year

### DIFF
--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -1,0 +1,19 @@
+name: Run strict style checks
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  strict-style:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: '.github/workflows/style-requirements.txt'
+    - run: python -m pip install -r .github/workflows/style-requirements.txt
+    - run: |
+        # Report on out-of-date copyright years.
+        python -m flake8 --select H102 .

--- a/.github/workflows/style-requirements.txt
+++ b/.github/workflows/style-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+flake8-ets

--- a/etstool.py
+++ b/etstool.py
@@ -94,6 +94,11 @@ SUPPORTED_RUNTIMES = ["3.8", "3.11"]
 #: Default Python version to use.
 DEFAULT_RUNTIME = "3.8"
 
+#: Copyright end year expected by the merge-blocking style check. We hard-code
+#: this (rather than using the current year) to give us a buffer on CI failures
+#: when January 1st rolls around.
+EXPECTED_COPYRIGHT_END_YEAR = 2025
+
 
 def edm_dependencies(runtime):
     """
@@ -313,6 +318,7 @@ def flake8(edm, runtime, environment):
     ]
     commands = [
         "{edm} run -e {environment} -- python -m flake8 "
+        f"--copyright-end-year {EXPECTED_COPYRIGHT_END_YEAR} "
         + " ".join(targets)
     ]
     execute(commands, parameters)


### PR DESCRIPTION
On each new-year rollover, the first PR created in the new year can't be merged because the H102 copyright-end-year style check fails (the headers still reference the previous year). This turns passing CI into failing CI overnight.

This adopts the approach from enthought/envisage#596, adapted to apptools' EDM-based style check:

- **Merge-blocking check** (`etstool.py flake8`, run in the *Test with EDM* workflow): hard-code the copyright end year via a new `EXPECTED_COPYRIGHT_END_YEAR` constant near the top of `etstool.py`, so a new year doesn't abruptly break CI. This year should be bumped as early as possible each year, and definitely before any release.
- **New non-blocking strict check** (`.github/workflows/check-style-strict.yml`): runs `flake8 --select H102 .` using the *current* year, so out-of-date copyright headers still show a prominent red ✗ without blocking merges. It installs flake8 + flake8-ets from a new `.github/workflows/style-requirements.txt`.

The copyright headers themselves will be bumped to 2026 in a follow-up PR.

Note: the strict workflow only *reports* without blocking as long as it isn't a required status check in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)