### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the target commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up bootstrap Python (3.10)
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -31,12 +31,12 @@ jobs:
       - name: Install necessary packages to the bootstrap environment
         run: python -m pip install -r .github/workflows/bootstrap-requirements.txt
       - name: Cache EDM packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v4.2
+        uses: enthought/setup-edm-action@e68a4e0282298d695020fb21b4d3e93c3ac3c11f # v4.2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Check out the release commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Install Python packages needed for build and upload

--- a/.github/workflows/test-minimal-dependencies.yml
+++ b/.github/workflows/test-minimal-dependencies.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     - name: Get apptools source
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install local package

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the target commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up bootstrap Python (3.10)
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -31,12 +31,12 @@ jobs:
       - name: Install necessary packages to the bootstrap environment
         run: python -m pip install -r .github/workflows/bootstrap-requirements.txt
       - name: Cache EDM packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v4.2
+        uses: enthought/setup-edm-action@e68a4e0282298d695020fb21b4d3e93c3ac3c11f # v4.2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install test environment

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     - name: Get apptools source
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages


### PR DESCRIPTION
## Summary

Hardens CI supply-chain security by pinning all external GitHub Actions to immutable commit SHAs instead of mutable version tags, and adds a Dependabot cooldown. This mirrors enthought/envisage#604.

### Why

A `uses: owner/repo@v6` reference resolves through a **mutable** git tag. If an attacker compromises an action's repository — or just gains the ability to move a tag — they can retarget `v6` at malicious code, and every workflow pinned to that tag runs it on the next CI run, with access to that job's secrets. This is what happened in the **March 2025 `tj-actions/changed-files` compromise**, where version tags were retroactively moved to a commit that exfiltrated CI secrets. Full-SHA pins are immutable, so each run is reproducible and immune to tag-move attacks. Follows [GitHub's security-hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### Changes

- Pin all external actions to commit SHAs with a trailing version comment:

  | Action | SHA | Version |
  |---|---|---|
  | `actions/checkout` | `df4cb1c` | v6.0.3 |
  | `actions/setup-python` | `ece7cb0` | v6.3.0 |
  | `actions/cache` | `55cc834` | v6.1.0 |
  | `enthought/setup-edm-action` | `e68a4e0` | v4.2 |

- Add a **7-day Dependabot cooldown** (`cooldown: default-days: 7`) so action updates aren't picked up until they've been published for a week, reducing exposure to a compromised release that gets yanked shortly after publication.

Dependabot continues to maintain the SHA pins, bumping both the SHA and the version comment. The pinned versions match what apptools already used (checkout/setup-python/cache v6, setup-edm-action v4.2); this change is functionally a no-op beyond the pinning itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)