### PR TITLE
Use "current" copyright-end-year in the strict style check

### DIFF
--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -14,6 +14,5 @@ jobs:
         cache: 'pip'
         cache-dependency-path: '.github/workflows/style-requirements.txt'
     - run: python -m pip install -r .github/workflows/style-requirements.txt
-    - run: |
-        # Report on out-of-date copyright years.
-        python -m flake8 --select H102 .
+    - name: Report on out-of-date copyright end years
+      run: python -m flake8 --select H102 --copyright-end-year current .

--- a/.github/workflows/style-requirements.txt
+++ b/.github/workflows/style-requirements.txt
@@ -1,2 +1,2 @@
 flake8
-flake8-ets
+flake8-ets >= 1.1.0

--- a/etstool.py
+++ b/etstool.py
@@ -94,11 +94,6 @@ SUPPORTED_RUNTIMES = ["3.8", "3.11"]
 #: Default Python version to use.
 DEFAULT_RUNTIME = "3.8"
 
-#: Copyright end year expected by the merge-blocking style check. We hard-code
-#: this (rather than using the current year) to give us a buffer on CI failures
-#: when January 1st rolls around.
-EXPECTED_COPYRIGHT_END_YEAR = 2026
-
 
 def edm_dependencies(runtime):
     """
@@ -318,7 +313,6 @@ def flake8(edm, runtime, environment):
     ]
     commands = [
         "{edm} run -e {environment} -- python -m flake8 "
-        f"--copyright-end-year {EXPECTED_COPYRIGHT_END_YEAR} "
         + " ".join(targets)
     ]
     execute(commands, parameters)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [flake8]
 ignore = E266, W503
+# Pin the year so style checks don't fail when the year rolls over.
+copyright-end-year = 2026
 per-file-ignores = 
     */api.py:F401,
     */__init__.py:F401,


### PR DESCRIPTION
Follow-up cleanup to #370, mirroring enthought/envisage#607.

That PR adopted a hard-coded copyright end year to avoid CI breaking on the new-year rollover, but couldn't express "use the current year" for the strict check. [ets-copyright-checker](https://github.com/enthought/ets-copyright-checker) (`flake8-ets`) 1.1.0 now supports `--copyright-end-year current`, so we can do the cleanup that PR wanted:

- Pin the buffered copyright end year in `setup.cfg` (`copyright-end-year = 2026`), so it's the single source of truth used by both the merge-blocking style check (`etstool.py flake8`) and local `flake8` runs.
- Drop the `--copyright-end-year` override (and the now-unused `EXPECTED_COPYRIGHT_END_YEAR` constant) from `etstool.py`; it just runs `flake8` now.
- Have the strict style check override the pinned value with `--copyright-end-year current` to report out-of-date copyright end years.

Pins `flake8-ets >= 1.1.0`, since the `current` value is only available from that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)